### PR TITLE
Fix docs typo in web server

### DIFF
--- a/src/check_tls/web_server.py
+++ b/src/check_tls/web_server.py
@@ -26,7 +26,7 @@ def get_flask_app():
     Create and return a Flask app instance for WSGI servers.
 
     This function provides a Flask app instance with similar configuration
-    as run_server, suitable zfor deployment with WSGI servers like waitress.
+    as run_server, suitable for deployment with WSGI servers like waitress.
 
     Returns:
         Flask: Configured Flask application instance.


### PR DESCRIPTION
## Summary
- fix a typo in `web_server.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684511878890832ebe41de548630f334