### PR TITLE
Improve CLI progress output

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ check-tls google.com https://github.com:443 -j report.json
 
 Human-readable output (default), or use `-j` for JSON and `-c` for CSV.
 
+When analyzing several domains, the CLI now shows a small progress message for
+each domain (e.g. `🔎 [2/3] Analyzing example.com:443... done`).
+
 **Key options:**
 
 - `-j, --json FILE`   Output JSON (use "-" for stdout)                                  

--- a/src/check_tls/main.py
+++ b/src/check_tls/main.py
@@ -455,9 +455,12 @@ def main():
             logger.info(
                 f"Starting analysis for: {[item['original_entry'] for item in parsed_domains_for_analysis]}")
             results = []
-            # Analyze each domain entry individually
-            for item in parsed_domains_for_analysis:
+            # Analyze each domain entry individually with simple progress output
+            total = len(parsed_domains_for_analysis)
+            for idx, item in enumerate(parsed_domains_for_analysis, start=1):
                 logger.debug(f"Analyzing {item['host']}:{item['port']}")
+                domain_display = f"{item['host']}:{item['port']}"
+                print(f"\033[96m🔎 [{idx}/{total}] Analyzing {domain_display}...\033[0m", end='', flush=True)
                 results.append(
                     analyze_certificates(
                         domain=item['host'],
@@ -469,6 +472,7 @@ def main():
                         perform_ocsp_check=not args.no_ocsp_check
                     )
                 )
+                print(" \033[92mdone\033[0m")
             # Print human-readable output directly to the console
             print_human_summary(results)
         # If JSON or CSV output is requested, call run_analysis which handles the analysis and file writing.


### PR DESCRIPTION
## Summary
- add progress messages when analyzing multiple domains
- document progress indicator in README

## Testing
- `python -m py_compile src/check_tls/main.py`
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_68459042dbe0832e8cdcb7546fd62de8