### PR TITLE
Add DNS CAA check

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A powerful, developer-friendly Python tool to analyze TLS/SSL certificates for a
 - **Profile Detection**: Detects usage profiles (server, email, code signing, etc.)
 - **CRL & Transparency**: Checks CRL status and certificate transparency logs
 - **OCSP Check**: Perform OCSP revocation checks for leaf certificates.
+- **CAA Check**: Display DNS CAA records for the domain.
 - **Flexible Output**: Human-readable (color), JSON, CSV
 - **Web UI**: Interactive browser-based analysis
 - **Dockerized**: Use with zero local setup
@@ -132,6 +133,7 @@ each domain (e.g. `🔎 [2/3] Analyzing example.com:443... done`).
 - `--no-transparency` Skip transparency check
 - `--no-crl-check`    Skip CRL check
 - `--no-ocsp-check`   Disable OCSP revocation check (enabled by default)
+- `--no-caa-check`    Disable DNS CAA check
 
 ---
 
@@ -150,6 +152,7 @@ The TLS Analyzer also provides a REST API for programmatic access. By default, t
   - `no_transparency` (optional, boolean): Skip certificate transparency check
   - `no_crl_check` (optional, boolean): Disable CRL check
   - `no_ocsp_check` (optional, boolean): Disable OCSP check
+  - `no_caa_check` (optional, boolean): Disable CAA check
 
 #### Example curl Request
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "flask>=3.1.0,<4.0.0",
     "shtab>=1.7.1,<2.0.0",
     "requests>=2.31.0,<3.0.0",
+    "dnspython>=2.4.2,<3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/check_tls/main.py
+++ b/src/check_tls/main.py
@@ -183,17 +183,20 @@ def print_human_summary(results):
         print("\n\033[1mDNS CAA Records:\033[0m")
         caa_check = result.get("caa_check", {})
         if not caa_check.get("checked"):
-            print("  Status      : \033[93mSkipped\033[0m")
+            print("  Status      : \033[93mNOT DEFINED\033[0m")
         elif caa_check.get("error"):
+            print("  Status      : \033[91mKO\033[0m")
             print(f"  Error       : \033[91m{caa_check['error']}\033[0m")
         elif caa_check.get("found"):
+            print("  Status      : \033[92mOK\033[0m")
             for rec in caa_check.get("records", []):
                 flags = rec.get('flags', '')
                 tag = rec.get('tag', '')
                 value = rec.get('value', '')
                 print(f"  {tag} = {value} (flags: {flags})")
         else:
-            print("  No CAA records found.")
+            print("  Status      : \033[91mKO\033[0m")
+            print("  Detail      : No CAA records found.")
 
         # Certificate Chain Details
         # Lists details for each certificate in the chain, including intermediates and root.

--- a/src/check_tls/main.py
+++ b/src/check_tls/main.py
@@ -195,8 +195,7 @@ def print_human_summary(results):
                 value = rec.get('value', '')
                 print(f"  {tag} = {value} (flags: {flags})")
         else:
-            print("  Status      : \033[91mKO\033[0m")
-            print("  Detail      : No CAA records found.")
+            print("  Status      : \033[93mNOT DEFINED\033[0m")
 
         # Certificate Chain Details
         # Lists details for each certificate in the chain, including intermediates and root.
@@ -289,13 +288,12 @@ def print_human_summary(results):
             details = trans.get('details', {})
             links = trans.get('crtsh_report_links', {})
             total = trans.get('crtsh_records_found', 0)
-            # Display errors encountered during the crt.sh query
             if trans.get('errors'):
-                print("  \033[91mErrors found during crt.sh query:\033[0m") # Red for errors (\033[91m)
+                print("  Status: \033[93mNOT DEFINED\033[0m")
                 for d, err in trans['errors'].items():
                     link = links.get(d)
                     link_str = f" (See: {link})" if link else ""
-                    print(f"    ❌ {d}: Error: {err}{link_str}")
+                    print(f"    ⚠️ {d}: {err}{link_str}")
             # Display details of records found on crt.sh
             if details:
                 print("  \033[92mTransparency log records (crt.sh):\033[0m") # Green for records found (\033[92m)

--- a/src/check_tls/main.py
+++ b/src/check_tls/main.py
@@ -179,6 +179,22 @@ def print_human_summary(results):
             else:
                 print("  Detail      : No additional details.")
 
+        # DNS CAA section
+        print("\n\033[1mDNS CAA Records:\033[0m")
+        caa_check = result.get("caa_check", {})
+        if not caa_check.get("checked"):
+            print("  Status      : \033[93mSkipped\033[0m")
+        elif caa_check.get("error"):
+            print(f"  Error       : \033[91m{caa_check['error']}\033[0m")
+        elif caa_check.get("found"):
+            for rec in caa_check.get("records", []):
+                flags = rec.get('flags', '')
+                tag = rec.get('tag', '')
+                value = rec.get('value', '')
+                print(f"  {tag} = {value} (flags: {flags})")
+        else:
+            print("  No CAA records found.")
+
         # Certificate Chain Details
         # Lists details for each certificate in the chain, including intermediates and root.
         # Colorize the count based on whether certificates were found.
@@ -341,6 +357,8 @@ def create_parser():
                         help='Disable CRL check for the leaf certificate')
     parser.add_argument('--no-ocsp-check', action='store_true',
                         help='Disable OCSP check for the leaf certificate')
+    parser.add_argument('--no-caa-check', action='store_true',
+                        help='Disable DNS CAA record check')
 
     # Add shtab completion argument using the parser program name
     prog_name = parser.prog  # Get the program name (e.g., 'check-tls')
@@ -469,7 +487,8 @@ def main():
                         insecure=args.insecure,
                         skip_transparency=args.no_transparency,
                         perform_crl_check=not args.no_crl_check,
-                        perform_ocsp_check=not args.no_ocsp_check
+                        perform_ocsp_check=not args.no_ocsp_check,
+                        perform_caa_check=not args.no_caa_check
                     )
                 )
                 print(" \033[92mdone\033[0m")
@@ -488,7 +507,8 @@ def main():
                 insecure=args.insecure,
                 skip_transparency=args.no_transparency,
                 perform_crl_check=not args.no_crl_check,
-                perform_ocsp_check=not args.no_ocsp_check
+                perform_ocsp_check=not args.no_ocsp_check,
+                perform_caa_check=not args.no_caa_check
             )
 
 

--- a/src/check_tls/static/js/app.js
+++ b/src/check_tls/static/js/app.js
@@ -65,6 +65,13 @@ document.addEventListener('DOMContentLoaded', function() {
     return '<span class="badge badge-expired">Error</span>'; // Default for other cases like error
   }
 
+  function caaBadge(caa) {
+    if (!caa || !caa.checked) return '<span class="badge bg-secondary">N/A</span>';
+    if (caa.error) return '<span class="badge badge-expired">Error</span>';
+    if (caa.found) return '<span class="badge badge-ok">Found</span>';
+    return '<span class="badge badge-warning">None</span>';
+  }
+
   function transparencyBadge(transparencyData) {
     // Updated based on Python output structure:
     // transparencyData is expected to be result.transparency
@@ -115,6 +122,7 @@ document.addEventListener('DOMContentLoaded', function() {
           </td>
           <td data-bs-toggle="tooltip" data-bs-title="Certificate Revocation List (CRL) check status for the leaf certificate.">${crlBadge(r.crl_check)}</td>
           <td data-bs-toggle="tooltip" data-bs-title="Online Certificate Status Protocol (OCSP) check status for the leaf certificate.">${ocspBadge(r.ocsp_check)}</td>
+          <td data-bs-toggle="tooltip" data-bs-title="Presence of DNS CAA records for the domain.">${caaBadge(r.caa_check)}</td>
           <td data-bs-toggle="tooltip" data-bs-title="Certificate Transparency (CT) log check status.">${transparencyBadge(r.transparency)}</td>
           <td data-bs-toggle="tooltip" data-bs-title="Link to crt.sh for the certificate or domain.">${crtshAnchor}</td>
           <td>
@@ -137,6 +145,7 @@ document.addEventListener('DOMContentLoaded', function() {
   function renderResult(result, idx=0) {
     const leaf = (result.certificates || []).find(c => c.chain_index === 0 && !c.error) || {};
     const transparencyDetailsHtml = renderTransparencyDetailsTable(result.transparency, idx);
+    const caaDetailsHtml = renderCaaDetails(result.caa_check, idx);
     // Quick info
     // Determine CSS class for expiry text/badge based on days remaining
     // expired: Certificate has expired (days < 0)
@@ -195,6 +204,7 @@ document.addEventListener('DOMContentLoaded', function() {
               </div>
             </div>
           </div>
+          ${caaDetailsHtml}
           ${transparencyDetailsHtml}
         </div>
       </div>
@@ -295,6 +305,62 @@ document.addEventListener('DOMContentLoaded', function() {
       </div>`;
   }
 
+  function renderCaaDetails(caaData, parentIdx) {
+    if (!caaData || !caaData.checked) {
+      return `
+        <div class="accordion-item">
+          <h2 class="accordion-header" id="heading-caa-${parentIdx}">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-caa-${parentIdx}">
+              DNS CAA Records
+            </button>
+          </h2>
+          <div id="collapse-caa-${parentIdx}" class="accordion-collapse collapse" aria-labelledby="heading-caa-${parentIdx}">
+            <div class="accordion-body">
+              <p class="text-muted">CAA check was skipped.</p>
+            </div>
+          </div>
+        </div>`;
+    }
+
+    if (caaData.error) {
+      return `
+        <div class="accordion-item">
+          <h2 class="accordion-header" id="heading-caa-${parentIdx}">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-caa-${parentIdx}">
+              DNS CAA Records
+            </button>
+          </h2>
+          <div id="collapse-caa-${parentIdx}" class="accordion-collapse collapse" aria-labelledby="heading-caa-${parentIdx}">
+            <div class="accordion-body">
+              <div class="alert alert-danger">${caaData.error}</div>
+            </div>
+          </div>
+        </div>`;
+    }
+
+    let rows = '';
+    if (Array.isArray(caaData.records)) {
+      caaData.records.forEach(r => {
+        rows += `<tr><td>${r.flags}</td><td>${r.tag}</td><td>${r.value}</td></tr>`;
+      });
+    }
+    const table = rows ? `<table class="table table-sm table-bordered"><thead><tr><th>Flags</th><th>Tag</th><th>Value</th></tr></thead><tbody>${rows}</tbody></table>` : '<p class="text-muted">No CAA records found.</p>';
+
+    return `
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="heading-caa-${parentIdx}">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-caa-${parentIdx}">
+            DNS CAA Records
+          </button>
+        </h2>
+        <div id="collapse-caa-${parentIdx}" class="accordion-collapse collapse" aria-labelledby="heading-caa-${parentIdx}">
+          <div class="accordion-body">
+            ${table}
+          </div>
+        </div>
+      </div>`;
+  }
+
   // Certificate chain details as HTML table (can be improved/extended)
   function renderChainTable(result) {
     // Helper function to create a table cell with a tooltip
@@ -336,13 +402,15 @@ document.addEventListener('DOMContentLoaded', function() {
     const insecure = formData.get('insecure') === 'true';
     const noTransparency = formData.get('no_transparency') === 'true';
     const noCrlCheck = formData.get('no_crl_check') === 'true';
+    const noCaaCheck = formData.get('no_caa_check') === 'true';
 
     const payload = {
       domains: domainsArray,
       connect_port: connectPort,
       insecure: insecure,
       no_transparency: noTransparency,
-      no_crl_check: noCrlCheck
+      no_crl_check: noCrlCheck,
+      no_caa_check: noCaaCheck
     };
 
     fetch('/api/analyze', {

--- a/src/check_tls/static/js/app.js
+++ b/src/check_tls/static/js/app.js
@@ -69,7 +69,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!caa || !caa.checked) return '<span class="badge bg-secondary">NOT DEFINED</span>';
     if (caa.error) return '<span class="badge badge-expired">KO</span>';
     if (caa.found) return '<span class="badge badge-ok">OK</span>';
-    return '<span class="badge badge-expired">KO</span>';
+    return '<span class="badge badge-warning">NOT DEFINED</span>';
   }
 
   function transparencyBadge(transparencyData) {
@@ -83,8 +83,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!transparencyData.checked) return '<span class="badge bg-secondary">N/A (Skipped)</span>';
 
     if (transparencyData.errors && Object.keys(transparencyData.errors).length > 0) {
-        // If there are errors for any domain part, mark as error
-        return '<span class="badge badge-expired">Error</span>';
+        return '<span class="badge badge-warning">NOT DEFINED</span>';
     }
     // Check if records were found. crtsh_records_found can be 0.
     if (typeof transparencyData.crtsh_records_found === 'number' && transparencyData.crtsh_records_found > 0) {
@@ -240,7 +239,7 @@ document.addEventListener('DOMContentLoaded', function() {
           : '-';
         let statusBadge = '';
         if (transparencyData.errors && transparencyData.errors[domain]) {
-            statusBadge = '<span class="badge bg-danger">Error</span>';
+            statusBadge = '<span class="badge bg-warning">Not Defined</span>';
         } else if (recordCount === 'Error/Timeout') {
             statusBadge = '<span class="badge bg-warning">Timeout/Error</span>';
         } else if (recordCount > 0) {
@@ -266,7 +265,7 @@ document.addEventListener('DOMContentLoaded', function() {
             tableRows += `
               <tr>
                 <td>${domain}</td>
-                <td class="text-center"><span class="badge bg-danger">Error: ${transparencyData.errors[domain]}</span></td>
+                <td class="text-center"><span class="badge bg-warning">Not Defined</span></td>
                 <td class="text-center">${crtshLink}</td>
               </tr>`;
         }

--- a/src/check_tls/static/js/app.js
+++ b/src/check_tls/static/js/app.js
@@ -46,6 +46,11 @@ document.addEventListener('DOMContentLoaded', function() {
     if (support === false) return '<span class="badge badge-expired">No</span>';
     return '<span class="badge badge-warning">?</span>';
   }
+
+  function displayTlsVersion(version) {
+    if (!version) return '-';
+    return version === 'TLSv1.3' ? '' : version;
+  }
   function crlBadge(crl) {
     if (!crl || !crl.checked) return '<span class="badge bg-secondary">N/A</span>';
     if (crl.leaf_status === "good") return '<span class="badge badge-ok">Good</span>';
@@ -116,7 +121,7 @@ document.addEventListener('DOMContentLoaded', function() {
               ${expiryBadge(leaf.days_remaining ?? 0)}
           </td>
           <td data-bs-toggle="tooltip" data-bs-title="Issuer of the leaf certificate.">${leaf.issuer || '-'}</td>
-          <td data-bs-toggle="tooltip" data-bs-title="TLS version used for the connection and TLS 1.3 support.">${(r.connection_health && r.connection_health.tls_version) || '-' }
+          <td data-bs-toggle="tooltip" data-bs-title="TLS version used for the connection and TLS 1.3 support.">${displayTlsVersion(r.connection_health && r.connection_health.tls_version)}
               ${tls13Badge(r.connection_health && r.connection_health.supports_tls13)}
           </td>
           <td data-bs-toggle="tooltip" data-bs-title="Certificate Revocation List (CRL) check status for the leaf certificate.">${crlBadge(r.crl_check)}</td>
@@ -183,7 +188,7 @@ document.addEventListener('DOMContentLoaded', function() {
           </div>
           <div class="col-6 col-md-3" data-bs-toggle="tooltip" data-bs-title="TLS version used for the connection and TLS 1.3 support.">
             <span class="fw-semibold text-muted">TLS:</span><br>
-            <span class="fs-6">${(result.connection_health && result.connection_health.tls_version) || '-'}</span>
+            <span class="fs-6">${displayTlsVersion(result.connection_health && result.connection_health.tls_version)}</span>
             ${tls13Badge(result.connection_health && result.connection_health.supports_tls13)}
           </div>
         </div>

--- a/src/check_tls/static/js/app.js
+++ b/src/check_tls/static/js/app.js
@@ -66,10 +66,10 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   function caaBadge(caa) {
-    if (!caa || !caa.checked) return '<span class="badge bg-secondary">N/A</span>';
-    if (caa.error) return '<span class="badge badge-expired">Error</span>';
-    if (caa.found) return '<span class="badge badge-ok">Found</span>';
-    return '<span class="badge badge-warning">None</span>';
+    if (!caa || !caa.checked) return '<span class="badge bg-secondary">NOT DEFINED</span>';
+    if (caa.error) return '<span class="badge badge-expired">KO</span>';
+    if (caa.found) return '<span class="badge badge-ok">OK</span>';
+    return '<span class="badge badge-expired">KO</span>';
   }
 
   function transparencyBadge(transparencyData) {

--- a/src/check_tls/templates/index.html
+++ b/src/check_tls/templates/index.html
@@ -25,26 +25,30 @@
       <label for="domains" class="form-label fw-bold">Domains to analyze <span class="text-muted">(comma or space separated)</span>:</label>
       <input type="text" class="form-control form-control-lg" id="domains" name="domains" placeholder="e.g. example.com test.org:8443" required>
     </div>
-    <div class="mb-3 row g-2">
+    <div class="mb-3 row g-2 align-items-end">
       <div class="col-12 col-md-4">
         <label for="connect_port" class="form-label">Default Port</label>
         <input type="number" class="form-control" id="connect_port" name="connect_port" value="443" min="1" max="65535">
       </div>
-      <div class="col-4 col-md-2 form-check mt-4">
-        <input class="form-check-input" type="checkbox" id="insecure" name="insecure" value="true">
-        <label class="form-check-label" for="insecure">Ignore SSL errors</label>
-      </div>
-      <div class="col-4 col-md-3 form-check mt-4">
-        <input class="form-check-input" type="checkbox" id="no_transparency" name="no_transparency" value="true">
-        <label class="form-check-label" for="no_transparency">Skip Transparency Check</label>
-      </div>
-      <div class="col-4 col-md-3 form-check mt-4">
-        <input class="form-check-input" type="checkbox" id="no_crl_check" name="no_crl_check" value="true">
-        <label class="form-check-label" for="no_crl_check">Disable CRL Check</label>
-      </div>
-      <div class="col-4 col-md-3 form-check mt-4">
-        <input class="form-check-input" type="checkbox" id="no_caa_check" name="no_caa_check" value="true">
-        <label class="form-check-label" for="no_caa_check">Disable CAA Check</label>
+      <div class="col-12 col-md-8">
+        <div class="d-flex flex-wrap gap-3 mt-4" id="option-container">
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="insecure" name="insecure" value="true">
+            <label class="form-check-label" for="insecure">Ignore SSL errors</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="no_transparency" name="no_transparency" value="true">
+            <label class="form-check-label" for="no_transparency">Skip Transparency Check</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="no_crl_check" name="no_crl_check" value="true">
+            <label class="form-check-label" for="no_crl_check">Disable CRL Check</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="no_caa_check" name="no_caa_check" value="true">
+            <label class="form-check-label" for="no_caa_check">Disable CAA Check</label>
+          </div>
+        </div>
       </div>
     </div>
     <button type="submit" class="btn btn-primary btn-lg w-100 mt-2">Analyze</button>

--- a/src/check_tls/templates/index.html
+++ b/src/check_tls/templates/index.html
@@ -42,6 +42,10 @@
         <input class="form-check-input" type="checkbox" id="no_crl_check" name="no_crl_check" value="true">
         <label class="form-check-label" for="no_crl_check">Disable CRL Check</label>
       </div>
+      <div class="col-4 col-md-3 form-check mt-4">
+        <input class="form-check-input" type="checkbox" id="no_caa_check" name="no_caa_check" value="true">
+        <label class="form-check-label" for="no_caa_check">Disable CAA Check</label>
+      </div>
     </div>
     <button type="submit" class="btn btn-primary btn-lg w-100 mt-2">Analyze</button>
   </form>
@@ -65,6 +69,7 @@
                 <th>TLS</th>
                 <th>CRL</th>
                 <th>OCSP</th>
+                <th>CAA</th>
                 <th>Transparency</th>
                 <th>crt.sh</th>
                 <th>Action</th>

--- a/src/check_tls/utils/dns_utils.py
+++ b/src/check_tls/utils/dns_utils.py
@@ -35,7 +35,9 @@ def query_caa(domain: str) -> Dict[str, Any]:
             })
         result["found"] = len(result["records"]) > 0
     except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
-        result["error"] = "No CAA records"
+        # No CAA records exist for the domain. This is not an error.
+        result["found"] = False
+        result["records"] = []
     except dns.exception.DNSException as exc:
         result["error"] = str(exc)
     return result

--- a/src/check_tls/utils/dns_utils.py
+++ b/src/check_tls/utils/dns_utils.py
@@ -29,9 +29,9 @@ def query_caa(domain: str) -> Dict[str, Any]:
         answers = dns.resolver.resolve(domain, "CAA")
         for rdata in answers:
             result["records"].append({
-                "flags": getattr(rdata, "flags", None),
-                "tag": getattr(rdata, "tag", ""),
-                "value": getattr(rdata, "value", ""),
+                "flags": int(getattr(rdata, "flags", 0)),
+                "tag": str(getattr(rdata, "tag", "")),
+                "value": str(getattr(rdata, "value", "")),
             })
         result["found"] = len(result["records"]) > 0
     except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):

--- a/src/check_tls/web_server.py
+++ b/src/check_tls/web_server.py
@@ -39,7 +39,7 @@ def get_flask_app():
     app = Flask(__name__,
                 template_folder=os.path.join(project_root, 'templates'),
                 static_folder=os.path.join(project_root, 'static'))
-    app.config['SCRIPT_ARGS'] = argparse.Namespace(insecure=False, no_transparency=False, no_crl_check=False, connect_port=443)
+    app.config['SCRIPT_ARGS'] = argparse.Namespace(insecure=False, no_transparency=False, no_crl_check=False, no_caa_check=False, connect_port=443)
 
     @app.route('/', methods=['GET'])
     def index():
@@ -57,6 +57,7 @@ def get_flask_app():
         insecure_checked = script_args.insecure
         no_transparency_checked = script_args.no_transparency
         no_crl_check_checked = script_args.no_crl_check
+        no_caa_check_checked = script_args.no_caa_check
         # Use script_args.connect_port if available (though not directly set by current CLI for server mode)
         # or default to 443 for the form's initial display.
         connect_port_value = getattr(script_args, 'connect_port', 443)
@@ -66,6 +67,7 @@ def get_flask_app():
             insecure_checked=insecure_checked,
             no_transparency_checked=no_transparency_checked,
             no_crl_check_checked=no_crl_check_checked,
+            no_caa_check_checked=no_caa_check_checked,
             connect_port_value=connect_port_value,
             get_tooltip=get_tooltip
         )
@@ -98,6 +100,7 @@ def get_flask_app():
         no_transparency_flag = bool(data.get('no_transparency', False))
         no_crl_check_flag = bool(data.get('no_crl_check', False))
         no_ocsp_check_flag = bool(data.get('no_ocsp_check', False))
+        no_caa_check_flag = bool(data.get('no_caa_check', False))
 
         try:
             connect_port_from_json = int(data.get('connect_port', 443))
@@ -137,10 +140,12 @@ def get_flask_app():
                 insecure=insecure_flag,
                 skip_transparency=no_transparency_flag,
                 perform_crl_check=not no_crl_check_flag,
-                perform_ocsp_check=not no_ocsp_check_flag
+                perform_ocsp_check=not no_ocsp_check_flag,
+                perform_caa_check=not no_caa_check_flag
             )
             # Include OCSP results in JSON API
             analysis_result["ocsp_check"] = analysis_result.get("ocsp_check", {})
+            analysis_result["caa_check"] = analysis_result.get("caa_check", {})
             results.append(analysis_result)
         return jsonify(results)
     return app


### PR DESCRIPTION
## Summary
- add dnspython dependency
- implement CAA DNS lookup utility
- expose CAA check in `analyze_certificates` and related CLI/web flows
- display CAA results in CLI and web UI
- document `--no-caa-check` flag

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_685dad9242bc832ea4258fa9398d7cb8