### PR TITLE
Handle missing OCSP URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,8 @@ The tool provides the following OCSP statuses for the leaf certificate:
 - **`revoked`**: The certificate has been revoked according to its OCSP responder.
 - **`unknown`**: The OCSP responder replied with an "unknown" status for the certificate. This means the responder doesn't have information about the certificate's status.
 - **`error`**: An error occurred while trying to perform the OCSP check (e.g., network issue, responder unavailable, malformed response). The specific error details are usually provided.
-- **`skipped`**: The OCSP check was not performed. This can happen if:
-    - The `--no-ocsp-check` flag was used.
-    - The certificate does not contain an OCSP URI.
-    - An OCSP check was not applicable for other reasons (e.g., for a CA certificate if only leaf certificate checks are configured).
+- **`no_ocsp_url`**: The certificate does not contain an OCSP URI.
+- **`skipped`**: The OCSP check was not performed because the `--no-ocsp-check` flag was used or it was not applicable.
 
 ---
 

--- a/src/check_tls/main.py
+++ b/src/check_tls/main.py
@@ -159,23 +159,25 @@ def print_human_summary(results):
 
             # Map OCSP status to colorized text
             ocsp_status_map = {
-                "good": "\033[92m✔️ Good\033[0m",  # Green
+                "good": "\033[92m✔️ Good\033[0m",      # Green
                 "revoked": "\033[91m❌ REVOKED\033[0m",  # Red
                 "unknown": "\033[93m❓ Unknown\033[0m",  # Yellow
-                "error": "\033[91m❌ Error\033[0m"  # Red
+                "no_ocsp_url": "\033[93mNOT DEFINED\033[0m",
+                "error": "\033[91m❌ Error\033[0m"      # Red
             }
-            status_text = ocsp_status_map.get(status, "\033[91m❌ Error\033[0m") # Default to Red Error
+            status_text = ocsp_status_map.get(status, "\033[91m❌ Error\033[0m")
 
             print(f"  Status      : {status_text}")
             print(f"  Checked URL : {checked_url}")
 
             # Display revocation reason or error
             revocation_reason = details.get("revocation_reason")
-            error_message = details.get("error")
+            error_message = details.get("error") or details.get("error_message") or details.get("message")
             if revocation_reason:
                 print(f"  Detail      : {revocation_reason}")
             elif error_message:
-                print(f"  Detail      : \033[91m{error_message}\033[0m") # Red for error message
+                color = "\033[93m" if status == "no_ocsp_url" else "\033[91m"
+                print(f"  Detail      : {color}{error_message}\033[0m")
             else:
                 print("  Detail      : No additional details.")
 

--- a/src/check_tls/static/js/app.js
+++ b/src/check_tls/static/js/app.js
@@ -407,6 +407,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const insecure = formData.get('insecure') === 'true';
     const noTransparency = formData.get('no_transparency') === 'true';
     const noCrlCheck = formData.get('no_crl_check') === 'true';
+    const noOcspCheck = formData.get('no_ocsp_check') === 'true';
     const noCaaCheck = formData.get('no_caa_check') === 'true';
 
     const payload = {
@@ -415,6 +416,7 @@ document.addEventListener('DOMContentLoaded', function() {
       insecure: insecure,
       no_transparency: noTransparency,
       no_crl_check: noCrlCheck,
+      no_ocsp_check: noOcspCheck,
       no_caa_check: noCaaCheck
     };
 

--- a/src/check_tls/static/js/app.js
+++ b/src/check_tls/static/js/app.js
@@ -66,6 +66,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (ocsp.status === "good") return '<span class="badge badge-ok">Good</span>';
     if (ocsp.status === "revoked") return '<span class="badge badge-expired">Revoked</span>';
     if (ocsp.status === "unknown") return '<span class="badge badge-warning">Unknown</span>';
+    if (ocsp.status === "no_ocsp_url") return '<span class="badge badge-warning">NOT DEFINED</span>';
     // Consider other statuses like 'error' or specific error messages if available in your data
     return '<span class="badge badge-expired">Error</span>'; // Default for other cases like error
   }
@@ -470,13 +471,17 @@ document.addEventListener('DOMContentLoaded', function() {
                 statusText = '❓ Unknown';
                 ocspStatusEl.className = 'text-secondary';
                 break;
+              case 'no_ocsp_url':
+                statusText = 'NOT DEFINED';
+                ocspStatusEl.className = 'text-warning';
+                break;
               default:
                 statusText = '❌ Error';
                 ocspStatusEl.className = 'text-danger';
             }
             ocspStatusEl.textContent = statusText;
-            ocspUrlEl.textContent    = (ocsp.details && ocsp.details.checked_url) || '';
-            ocspDetailEl.textContent = (ocsp.details && (ocsp.details.revocation_reason || ocsp.details.error)) || '';
+            ocspUrlEl.textContent    = ocsp.checked_url || '';
+            ocspDetailEl.textContent = (ocsp.details && (ocsp.details.revocation_reason || ocsp.details.error || ocsp.details.message)) || '';
           }
         }
       } else {

--- a/src/check_tls/templates/index.html
+++ b/src/check_tls/templates/index.html
@@ -26,12 +26,12 @@
       <input type="text" class="form-control form-control-lg" id="domains" name="domains" placeholder="e.g. example.com test.org:8443" required>
     </div>
     <div class="mb-3 row g-2 align-items-end">
-      <div class="col-12 col-md-4">
+      <div class="col-12 col-md-2">
         <label for="connect_port" class="form-label">Default Port</label>
         <input type="number" class="form-control" id="connect_port" name="connect_port" value="443" min="1" max="65535">
       </div>
-      <div class="col-12 col-md-8">
-        <div class="d-flex flex-wrap gap-3 mt-4" id="option-container">
+      <div class="col-12 col-md-10">
+        <div class="d-flex flex-wrap gap-3 mt-4 justify-content-end" id="option-container">
           <div class="form-check">
             <input class="form-check-input" type="checkbox" id="insecure" name="insecure" value="true">
             <label class="form-check-label" for="insecure">Ignore SSL errors</label>
@@ -43,6 +43,10 @@
           <div class="form-check">
             <input class="form-check-input" type="checkbox" id="no_crl_check" name="no_crl_check" value="true">
             <label class="form-check-label" for="no_crl_check">Disable CRL Check</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="no_ocsp_check" name="no_ocsp_check" value="true">
+            <label class="form-check-label" for="no_ocsp_check">Disable OCSP Check</label>
           </div>
           <div class="form-check">
             <input class="form-check-input" type="checkbox" id="no_caa_check" name="no_caa_check" value="true">


### PR DESCRIPTION
## Summary
- show `no_ocsp_url` status as `NOT DEFINED` in CLI
- display `NOT DEFINED` badge in web UI when a certificate lacks an OCSP URL
- document the new OCSP status in README

## Testing
- `python -m compileall -q src/check_tls`

------
https://chatgpt.com/codex/tasks/task_e_687f8547c12c832e9604f2419f45acc6