### PR TITLE
fix(security): add SSRF protection with IP blocklist validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ A powerful, developer-friendly Python tool to analyze TLS/SSL certificates for a
       - [Example JSON Response](#example-json-response)
   - [OCSP Status Explained](#ocsp-status-explained)
   - [🌐 Web Interface](#-web-interface)
+  - [🔒 Security](#-security)
+    - [SSRF Protection](#ssrf-protection)
+    - [Analyzing Internal Hosts](#analyzing-internal-hosts)
   - [✨ Shell Completion](#-shell-completion)
   - [🗂️ Project Structure](#️-project-structure)
   - [❓ FAQ](#-faq)
@@ -246,6 +249,47 @@ The tool provides the following OCSP statuses for the leaf certificate:
 
 ---
 
+## 🔒 Security
+
+### SSRF Protection
+
+Starting from version 1.8.0, `check-tls` includes built-in protection against Server-Side Request Forgery (SSRF) attacks. By default, the tool blocks connections to private and internal IP addresses to prevent malicious users from:
+
+- Scanning internal network ports
+- Accessing internal services
+- Enumerating private infrastructure
+
+**Blocked IP Ranges:**
+
+- Private networks: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- Loopback: `127.0.0.0/8`
+- Link-local: `169.254.0.0/16`
+- And other reserved ranges (see `SECURITY.md` for complete list)
+
+### Analyzing Internal Hosts
+
+For legitimate internal network analysis (e.g., in development or private infrastructure), you can disable SSRF protection using the `ALLOW_INTERNAL_IPS` environment variable:
+
+```sh
+# Allow analysis of internal IPs
+export ALLOW_INTERNAL_IPS=true
+check-tls 192.168.1.1
+
+# Or inline for a single command
+ALLOW_INTERNAL_IPS=true check-tls 10.0.0.50:8443
+
+# For the web server
+ALLOW_INTERNAL_IPS=true check-tls --server
+```
+
+**⚠️ Security Warning:**
+
+- **Never** set `ALLOW_INTERNAL_IPS=true` in production environments
+- Only use this in trusted, isolated development/testing environments
+- See `SECURITY.md` for detailed security documentation and best practices
+
+---
+
 ## ✨ Shell Completion
 
 `check-tls` supports shell completion for bash, zsh, and fish. To enable it, add the appropriate command to your shell's configuration file (`~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish`).
@@ -313,8 +357,14 @@ A: Use the `-k` or `--insecure` flag. This tells the tool to connect without val
 **Q: Can I use this tool without Python installed?**  
 A: Yes! The Docker image provides a self-contained environment with all dependencies. See the "With Docker" section for instructions.
 
-**Q: How do I get JSON or CSV output?**  
+**Q: How do I get JSON or CSV output?**
 A: Use `-j file.json` or `-c file.csv`. Use `-` as the filename to print to standard output.
+
+**Q: Can I analyze internal/private IP addresses?**
+A: By default, `check-tls` blocks connections to private IP ranges (192.168.x.x, 10.x.x.x, etc.) for security reasons. To analyze internal hosts in development/testing environments, use: `ALLOW_INTERNAL_IPS=true check-tls 192.168.1.1`. **Never use this in production!** See the Security section for more details.
+
+**Q: Why am I getting "Blocked connection to private/internal IP" errors?**
+A: This is the built-in SSRF protection. If you need to analyze internal hosts (e.g., in a development environment), use the `ALLOW_INTERNAL_IPS=true` environment variable. See the Security section for details and warnings.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ Server-Side Request Forgery (SSRF) is a vulnerability where an attacker can make
 
 ### Protection Mechanisms
 
-Starting from version 2.x, `check-tls` includes built-in SSRF protection that blocks connections to private and internal IP addresses.
+Starting from version 1.8.0, `check-tls` includes built-in SSRF protection that blocks connections to private and internal IP addresses.
 
 #### Blocked IP Ranges
 
@@ -123,7 +123,7 @@ We will respond within 48 hours and work with you to address the issue.
 
 ## Security Changelog
 
-### Version 2.x (2025)
+### Version 1.8.0 (2025)
 - Added SSRF protection with IP blocklist validation
 - Added XSS protection with HTML escaping in web interface
 - Added `ALLOW_INTERNAL_IPS` environment variable for controlled bypass

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,136 @@
+# Security Documentation
+
+## Overview
+
+This document describes the security features and considerations for the `check-tls` project.
+
+## SSRF Protection
+
+### What is SSRF?
+
+Server-Side Request Forgery (SSRF) is a vulnerability where an attacker can make the server initiate requests to internal or arbitrary destinations. In the context of `check-tls`, an attacker could potentially:
+
+- Scan internal network ports for TLS services
+- Enumerate internal hosts
+- Access services not exposed publicly
+- Bypass firewall rules
+
+### Protection Mechanisms
+
+Starting from version 2.x, `check-tls` includes built-in SSRF protection that blocks connections to private and internal IP addresses.
+
+#### Blocked IP Ranges
+
+The following IP ranges are blocked by default:
+
+**IPv4:**
+- `10.0.0.0/8` - Private network (RFC1918)
+- `172.16.0.0/12` - Private network (RFC1918)
+- `192.168.0.0/16` - Private network (RFC1918)
+- `127.0.0.0/8` - Loopback (RFC1122)
+- `169.254.0.0/16` - Link-local (RFC3927)
+- `0.0.0.0/8` - Current network (RFC1122)
+- `100.64.0.0/10` - Shared address space (RFC6598)
+- `192.0.0.0/24` - IETF protocol assignments (RFC6890)
+- `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24` - Documentation (RFC5737)
+- `198.18.0.0/15` - Benchmarking (RFC2544)
+- `224.0.0.0/4` - Multicast (RFC5771)
+- `240.0.0.0/4` - Reserved (RFC1112)
+- `255.255.255.255/32` - Broadcast (RFC919)
+
+**IPv6:**
+- `::1/128` - Loopback (RFC4291)
+- `fe80::/10` - Link-local (RFC4291)
+- `fc00::/7` - Unique local address (RFC4193)
+- `ff00::/8` - Multicast (RFC4291)
+- `::ffff:0:0/96` - IPv4-mapped IPv6 (RFC4291)
+- `2001:db8::/32` - Documentation (RFC3849)
+
+#### How It Works
+
+1. When analyzing a domain, `check-tls` first validates the target host
+2. If the host is an IP address, it checks against the blocklist
+3. If the host is a domain name, it resolves the domain to IP addresses
+4. All resolved IP addresses are checked against the blocklist
+5. If any resolved IP is in a blocked range, the connection is refused
+
+### Disabling SSRF Protection
+
+**⚠️ WARNING**: Only disable SSRF protection in trusted, isolated environments (e.g., development, testing).
+
+To allow connections to internal IPs, set the environment variable:
+
+```bash
+# Temporarily allow internal IPs for current session
+export ALLOW_INTERNAL_IPS=true
+check-tls 192.168.1.1
+
+# Or inline for a single command
+ALLOW_INTERNAL_IPS=true check-tls 192.168.1.1
+
+# For web server
+ALLOW_INTERNAL_IPS=true check-tls --server
+```
+
+### Security Best Practices
+
+#### For Deployment
+
+1. **Never disable SSRF protection in production** unless you have additional network-level controls
+2. **Use network segmentation** - Deploy `check-tls` in a DMZ or isolated network segment
+3. **Implement rate limiting** - Use a reverse proxy (nginx, Traefik) to limit requests
+4. **Monitor logs** - Watch for repeated attempts to access internal IPs
+5. **Keep dependencies updated** - Regularly update Python and all dependencies
+
+#### For Development
+
+1. **Use environment variables** - Configure `ALLOW_INTERNAL_IPS` only when needed
+2. **Test with safe targets** - Use public test domains for functional testing
+3. **Review logs** - Check security validation messages in debug mode
+
+#### Example Secure Deployment
+
+```bash
+# Docker deployment with security in mind
+docker run -d \
+  --name check-tls \
+  --network isolated-network \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges:true \
+  -p 127.0.0.1:8000:8000 \
+  check-tls:latest --server
+```
+
+## XSS Protection
+
+The web interface includes HTML escaping for all user-controlled data to prevent Cross-Site Scripting (XSS) attacks. Certificate fields (CN, Subject, Issuer, SANs) are sanitized before being displayed in the browser.
+
+## Reporting Security Issues
+
+If you discover a security vulnerability, please report it to:
+
+**Email**: obeone@obeone.org
+**Subject**: [SECURITY] check-tls vulnerability report
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+We will respond within 48 hours and work with you to address the issue.
+
+## Security Changelog
+
+### Version 2.x (2025)
+- Added SSRF protection with IP blocklist validation
+- Added XSS protection with HTML escaping in web interface
+- Added `ALLOW_INTERNAL_IPS` environment variable for controlled bypass
+- Created `security_utils.py` module for centralized security validations
+
+## Additional Resources
+
+- [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
+- [OWASP XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+- [CWE-918: Server-Side Request Forgery (SSRF)](https://cwe.mitre.org/data/definitions/918.html)

--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -13,11 +13,13 @@ from check_tls.utils.cert_utils import *
 from check_tls.utils.crl_utils import *
 from check_tls.utils.crtsh_utils import query_crtsh, query_crtsh_multi
 from check_tls.utils.dns_utils import query_caa
+from check_tls.utils.security_utils import validate_host_for_connection
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509.oid import ExtensionOID, ExtendedKeyUsageOID, AuthorityInformationAccessOID
 import urllib.request
 import json
+import os
 
 
 def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure: bool = False) -> Tuple[Optional[x509.Certificate], Optional[Dict[str, Any]]]:
@@ -57,6 +59,17 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
         context.minimum_version = ssl.TLSVersion.TLSv1_2
     except AttributeError:
         logger.warning("Could not set minimum TLS version on context (might be older Python/SSL version).")
+
+    # Security validation: Check if the host resolves to private/internal IPs
+    # This prevents SSRF attacks by blocking connections to internal networks
+    # Set ALLOW_INTERNAL_IPS=true environment variable to disable this protection
+    allow_private = os.getenv('ALLOW_INTERNAL_IPS', 'false').lower() == 'true'
+    is_valid, validation_error = validate_host_for_connection(domain, port, allow_private_ips=allow_private)
+
+    if not is_valid:
+        logger.error(f"Security validation failed for {domain}:{port}: {validation_error}")
+        conn_info["error"] = validation_error
+        return None, conn_info
 
     sock = None
     ssock = None

--- a/src/check_tls/utils/security_utils.py
+++ b/src/check_tls/utils/security_utils.py
@@ -1,0 +1,174 @@
+"""
+security_utils.py
+
+Security validation utilities for preventing SSRF and other attacks.
+Provides functions to validate domains and IP addresses before making connections.
+"""
+
+import ipaddress
+import socket
+import logging
+from typing import Tuple, Optional
+
+
+# Private/internal IP ranges that should be blocked to prevent SSRF attacks
+BLOCKED_IP_RANGES = [
+    ipaddress.ip_network('10.0.0.0/8'),       # RFC1918 - Private network
+    ipaddress.ip_network('172.16.0.0/12'),    # RFC1918 - Private network
+    ipaddress.ip_network('192.168.0.0/16'),   # RFC1918 - Private network
+    ipaddress.ip_network('127.0.0.0/8'),      # RFC1122 - Loopback
+    ipaddress.ip_network('169.254.0.0/16'),   # RFC3927 - Link-local
+    ipaddress.ip_network('0.0.0.0/8'),        # RFC1122 - Current network
+    ipaddress.ip_network('100.64.0.0/10'),    # RFC6598 - Shared address space
+    ipaddress.ip_network('192.0.0.0/24'),     # RFC6890 - IETF protocol assignments
+    ipaddress.ip_network('192.0.2.0/24'),     # RFC5737 - Documentation
+    ipaddress.ip_network('198.18.0.0/15'),    # RFC2544 - Benchmarking
+    ipaddress.ip_network('198.51.100.0/24'),  # RFC5737 - Documentation
+    ipaddress.ip_network('203.0.113.0/24'),   # RFC5737 - Documentation
+    ipaddress.ip_network('224.0.0.0/4'),      # RFC5771 - Multicast
+    ipaddress.ip_network('240.0.0.0/4'),      # RFC1112 - Reserved
+    ipaddress.ip_network('255.255.255.255/32'), # RFC919 - Broadcast
+    # IPv6 ranges
+    ipaddress.ip_network('::1/128'),          # RFC4291 - Loopback
+    ipaddress.ip_network('fe80::/10'),        # RFC4291 - Link-local
+    ipaddress.ip_network('fc00::/7'),         # RFC4193 - Unique local address
+    ipaddress.ip_network('ff00::/8'),         # RFC4291 - Multicast
+    ipaddress.ip_network('::ffff:0:0/96'),    # RFC4291 - IPv4-mapped IPv6
+    ipaddress.ip_network('2001:db8::/32'),    # RFC3849 - Documentation
+]
+
+
+def is_ip_blocked(ip_address_str: str) -> Tuple[bool, Optional[str]]:
+    """
+    Check if an IP address is in a blocked range (private/internal networks).
+
+    Args:
+        ip_address_str (str): The IP address to check as a string.
+
+    Returns:
+        Tuple[bool, Optional[str]]:
+            - True if the IP is blocked, False otherwise
+            - Error message if blocked, None otherwise
+
+    Example:
+        >>> is_ip_blocked('192.168.1.1')
+        (True, 'IP address 192.168.1.1 is in blocked range 192.168.0.0/16 (Private network)')
+        >>> is_ip_blocked('8.8.8.8')
+        (False, None)
+    """
+    try:
+        ip = ipaddress.ip_address(ip_address_str)
+        for network in BLOCKED_IP_RANGES:
+            if ip in network:
+                return True, f"IP address {ip_address_str} is in blocked range {network} (Private/internal network)"
+        return False, None
+    except ValueError as e:
+        # Not a valid IP address
+        return False, None
+
+
+def validate_host_for_connection(host: str, port: int, allow_private_ips: bool = False) -> Tuple[bool, Optional[str]]:
+    """
+    Validate a host before making a connection to prevent SSRF attacks.
+
+    This function checks if the host (domain or IP) resolves to a private/internal
+    IP address that could be exploited for SSRF attacks.
+
+    Args:
+        host (str): The hostname or IP address to validate.
+        port (int): The port number (for logging purposes).
+        allow_private_ips (bool): If True, allow connections to private IPs.
+                                  Defaults to False for security.
+
+    Returns:
+        Tuple[bool, Optional[str]]:
+            - True if validation passed (host is safe to connect to)
+            - Error message if validation failed, None otherwise
+
+    Example:
+        >>> validate_host_for_connection('example.com', 443)
+        (True, None)
+        >>> validate_host_for_connection('192.168.1.1', 443)
+        (False, 'Blocked connection to private IP...')
+    """
+    logger = logging.getLogger("certcheck")
+
+    # If private IPs are explicitly allowed, skip validation
+    if allow_private_ips:
+        logger.debug(f"Allowing connection to {host}:{port} (private IPs allowed)")
+        return True, None
+
+    # Check if host is already an IP address
+    try:
+        ip = ipaddress.ip_address(host)
+        is_blocked, block_msg = is_ip_blocked(str(ip))
+        if is_blocked:
+            error_msg = f"Blocked connection to private/internal IP: {block_msg}"
+            logger.warning(error_msg)
+            return False, error_msg
+        # IP is public, allow connection
+        return True, None
+    except ValueError:
+        # Not an IP address, it's a hostname - need to resolve it
+        pass
+
+    # Resolve hostname to IP address(es) and check each one
+    try:
+        resolved_ips = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM)
+        for result in resolved_ips:
+            family, socktype, proto, canonname, sockaddr = result
+            ip_str = sockaddr[0]  # Extract IP address
+
+            is_blocked, block_msg = is_ip_blocked(ip_str)
+            if is_blocked:
+                error_msg = f"Blocked connection to {host}:{port} - resolves to private/internal IP: {block_msg}"
+                logger.warning(error_msg)
+                return False, error_msg
+
+        # All resolved IPs are public, allow connection
+        logger.debug(f"Validated {host}:{port} - resolves to public IPs only")
+        return True, None
+
+    except socket.gaierror as e:
+        # DNS resolution failed - let the connection attempt handle this error
+        logger.debug(f"DNS resolution failed for {host}: {e}")
+        return True, None  # Allow the connection to proceed and fail naturally with proper error
+    except Exception as e:
+        # Unexpected error during validation - fail closed for security
+        error_msg = f"Unexpected error validating host {host}: {e}"
+        logger.error(error_msg)
+        return False, error_msg
+
+
+def is_port_allowed(port: int, allowed_ports: Optional[set] = None) -> Tuple[bool, Optional[str]]:
+    """
+    Check if a port is in the allowed list for TLS connections.
+
+    Args:
+        port (int): The port number to check.
+        allowed_ports (Optional[set]): Set of allowed port numbers.
+                                       If None, all ports 1-65535 are allowed.
+
+    Returns:
+        Tuple[bool, Optional[str]]:
+            - True if port is allowed, False otherwise
+            - Error message if blocked, None otherwise
+
+    Example:
+        >>> is_port_allowed(443, {443, 8443})
+        (True, None)
+        >>> is_port_allowed(22, {443, 8443})
+        (False, 'Port 22 is not in the allowed list: {443, 8443}')
+    """
+    # If no allowed_ports list is provided, allow all valid ports
+    if allowed_ports is None:
+        if 1 <= port <= 65535:
+            return True, None
+        else:
+            return False, f"Port {port} is out of valid range (1-65535)"
+
+    # Check against allowed ports list
+    if port in allowed_ports:
+        return True, None
+    else:
+        return False, f"Port {port} is not in the allowed list: {sorted(allowed_ports)}"


### PR DESCRIPTION
## 🔒 Security Fix: Server-Side Request Forgery (SSRF)

### Vulnerability Details
- **Type**: SSRF (Server-Side Request Forgery)
- **Severity**: MEDIUM
- **CVE**: N/A (Internal discovery)
- **Affected Component**: TLS connection module (`tls_checker.py`)

### Problem
The application allowed users to specify arbitrary domains/IPs and ports for TLS analysis without validation. An attacker could exploit this to:
- Scan internal network TLS ports
- Enumerate internal hosts
- Access services not exposed publicly
- Bypass firewall rules via the server

### Attack Scenario
1. Attacker identifies check-tls server has access to internal network
2. Attacker submits analysis requests for internal IPs:
   ```bash
   POST /api/analyze
   {"domains": ["192.168.1.1:443", "192.168.1.2:443", ..., "192.168.1.254:443"]}
   ```
3. Application connects to each internal IP
4. Attacker observes responses to identify active hosts and open TLS ports
5. Attacker discovers internal services for further attacks

### Solution
- Created `security_utils.py` module with IP validation functions
- Implemented blocklist of 23 private/internal IP ranges
- Validate all hostnames by resolving DNS and checking resolved IPs
- Added `ALLOW_INTERNAL_IPS` environment variable for legitimate internal use
- Integrated validation in `fetch_leaf_certificate_and_conn_info()`
- Created comprehensive `SECURITY.md` documentation

### Protected IP Ranges

**IPv4:**
- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (RFC1918 - Private)
- `127.0.0.0/8` (RFC1122 - Loopback)
- `169.254.0.0/16` (RFC3927 - Link-local)
- `0.0.0.0/8`, `100.64.0.0/10`, `192.0.0.0/24` (Various reserved)
- Documentation, benchmarking, multicast, broadcast ranges

**IPv6:**
- `::1/128` (RFC4291 - Loopback)
- `fe80::/10` (RFC4291 - Link-local)
- `fc00::/7` (RFC4193 - Unique local)
- `ff00::/8` (RFC4291 - Multicast)
- `::ffff:0:0/96`, `2001:db8::/32` (Mapped and documentation)

### Files Changed
- **New**: `src/check_tls/utils/security_utils.py` (174 lines)
- **New**: `SECURITY.md` (136 lines)
- **Modified**: `src/check_tls/tls_checker.py` (+13 lines)

### Configuration

**Default (Secure):**
```bash
check-tls example.com  # ✅ Allowed
check-tls 192.168.1.1  # ❌ Blocked
```

**Development Mode:**
```bash
export ALLOW_INTERNAL_IPS=true
check-tls 192.168.1.1  # ✅ Allowed
```

⚠️ **WARNING**: Never set `ALLOW_INTERNAL_IPS=true` in production!

### Testing
- Validated blocking of all private IP ranges
- Confirmed DNS resolution validation works correctly
- Tested environment variable override mechanism
- Verified error messages are clear and informative

### Security Impact
✅ **Prevents**:
- Internal network reconnaissance
- Port scanning via TLS connections
- Access to internal-only services
- SSRF-based attacks in cloud environments

⚙️ **Allows**:
- Legitimate internal network analysis (via flag)
- Public domain analysis (unchanged)
- Full functionality with security by default

### References
- [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
- [CWE-918: Server-Side Request Forgery (SSRF)](https://cwe.mitre.org/data/definitions/918.html)
- RFC1918, RFC1122, RFC3927 (IP range specifications)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)