### PR TITLE
fix(tls): correct argument order in _dnsname_match for wildcard SANs

### DIFF
--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -107,9 +107,11 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
         names = san_hosts.copy()
         if cn and cn not in names:
             names.insert(0, cn)
-        # Use internal _dnsname_match for wildcard support similar to match_hostname
+        # Use internal _dnsname_match for wildcard support similar to match_hostname.
+        # Signature is _dnsname_match(dn, hostname) — the certificate name (which
+        # may carry a wildcard) goes first, the hostname being checked second.
         from ssl import _dnsname_match
-        if not any(_dnsname_match(domain, name) for name in names):
+        if not any(_dnsname_match(name, domain) for name in names):
             validity_info = (
                 f" Valid from {cert.not_valid_before_utc.isoformat()}"
                 f" to {cert.not_valid_after_utc.isoformat()}."

--- a/tests/test_tls_checker.py
+++ b/tests/test_tls_checker.py
@@ -250,6 +250,53 @@ def base_analyze(domain, port, insecure):
     )
 
 
+def test_fetch_leaf_certificate_wildcard_san_matches_subdomain(monkeypatch):
+    cert, cert_path, key_path = generate_self_signed_cert(
+        "*.example.test", ["*.example.test", "example.test"],
+    )
+    port, stop_server = start_test_server(cert_path, key_path)
+
+    real_create_connection = socket.create_connection
+
+    def redirected(address, *args, **kwargs):
+        host, p = address
+        return real_create_connection(("127.0.0.1", p), *args, **kwargs)
+
+    monkeypatch.setattr(socket, "create_connection", redirected)
+    try:
+        fetched_cert, conn_info = fetch_leaf_certificate_and_conn_info(
+            "www.example.test", port=port, insecure=True
+        )
+        assert fetched_cert is not None
+        assert conn_info["error"] is None
+    finally:
+        stop_server()
+
+
+def test_fetch_leaf_certificate_wildcard_san_rejects_apex(monkeypatch):
+    cert, cert_path, key_path = generate_self_signed_cert(
+        "*.example.test", ["*.example.test"],
+    )
+    port, stop_server = start_test_server(cert_path, key_path)
+
+    real_create_connection = socket.create_connection
+
+    def redirected(address, *args, **kwargs):
+        host, p = address
+        return real_create_connection(("127.0.0.1", p), *args, **kwargs)
+
+    monkeypatch.setattr(socket, "create_connection", redirected)
+    try:
+        fetched_cert, conn_info = fetch_leaf_certificate_and_conn_info(
+            "example.test", port=port, insecure=True
+        )
+        assert fetched_cert is not None
+        err = conn_info["error"] or ""
+        assert "Hostname mismatch" in err
+    finally:
+        stop_server()
+
+
 def test_analyze_certificates_host_mismatch_propagates_error():
     cert, cert_path, key_path = generate_self_signed_cert(
         "example.com", ["example.com"],


### PR DESCRIPTION
## Summary
- Restore correct `_dnsname_match(dn, hostname)` argument order in `fetch_leaf_certificate_and_conn_info`. The previous order made wildcard SANs (e.g. `*.example.com`) fall through the no-wildcard branch and be compared literally, raising spurious `Hostname mismatch` errors for any subdomain served by a wildcard cert (reproduced live on `www.amfie.org`).
- Add two regression tests: one asserts a wildcard SAN matches a subdomain, the other confirms a lone wildcard does not match the apex.

## Test plan
- [x] `ALLOW_INTERNAL_IPS=true pytest tests/test_tls_checker.py -v` — 7/7 pass
- [x] `check-tls www.amfie.org` — status now `completed` (was `completed_with_errors` with `Hostname mismatch`)