### PR TITLE
chore(deps): bump cryptography to >=46.0.6,<47.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "cryptography>=44.0.3,<45.0.0",
+    "cryptography>=46.0.6,<47.0.0",
     "coloredlogs>=15.0.1,<16.0.0",
     "flask>=3.1.0,<4.0.0",
     "shtab>=1.7.1,<2.0.0",


### PR DESCRIPTION
## Summary
- Bump `cryptography` pin from `>=44.0.3,<45.0.0` to `>=46.0.6,<47.0.0` for security fixes shipped in the 46.0.x line.
- Verified on cryptography 46.0.7.

## Test plan
- [x] `ALLOW_INTERNAL_IPS=true pytest tests/` — 7/7 pass