### PR TITLE
feat(server): bind on :: for dual-stack IPv4/IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A powerful, developer-friendly Python tool to analyze TLS/SSL certificates for a
 - **Web UI**: Interactive browser-based analysis via a built-in Flask server.
 - **REST API**: Programmatic access for seamless integration into other tools.
 - **Dockerized**: Ready to use with zero local setup via Docker Hub or GHCR.
+- **IPv6 Ready**: The web server listens on all network interfaces (IPv4 & IPv6).
 
 ---
 
@@ -116,7 +117,7 @@ To run the interactive web UI, use the `--server` flag and map the port:
 docker run --rm -p 8000:8000 obeoneorg/check-tls:latest --server
 ```
 
-The web interface will be available at <http://localhost:8000>.
+The web interface will be available at <http://localhost:8000>. The server listens on all interfaces, so you can also access it via `http://<your-ip>:8000`.
 
 ---
 
@@ -171,7 +172,7 @@ To launch the interactive web interface, use the `--server` flag:
 check-tls --server
 ```
 
-Then, open <http://localhost:8000> in your browser.
+Then, open <http://localhost:8000> in your browser. The server listens on all network interfaces (IPv4 & IPv6).
 
 ---
 

--- a/src/check_tls/web_server.py
+++ b/src/check_tls/web_server.py
@@ -171,9 +171,9 @@ def run_server(args):
     and returns analysis results rendered in HTML or JSON format based on the
     Accept header.
     """
-    logging.info(f"Starting Flask server on http://0.0.0.0:{args.port}")
+    logging.info(f"Starting Flask server on http://[::]:{args.port}")
     try:
         app = get_flask_app()
-        app.run(host='0.0.0.0', port=args.port, debug=False)
+        app.run(host='::', port=args.port, debug=False)
     except Exception as e:
         logging.error(f"Failed to start Flask server: {e}")


### PR DESCRIPTION
## Summary
- Replace `host='0.0.0.0'` with `host='::'` in `run_server`, so the Flask development server listens on IPv6 (and IPv4 transparently via the dual-stack mapping on Linux/macOS).
- Update the log line to match (`http://[::]:{port}`).
- Document the IPv6-ready behavior in the README feature list and in the Docker/CLI server-mode notes.

This also aligns the code with `CLAUDE.md`, which already declares the server as binding on `::`.

## Test plan
- [ ] `check-tls --server -p 8000` then `curl -6 http://[::1]:8000/` and `curl http://127.0.0.1:8000/` both reach the UI.
- [ ] `docker run --rm -p 8000:8000 obeoneorg/check-tls:latest --server` still works.