### PR TITLE
fix(tls): assorted bug fixes from audit pass

### DIFF
--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -809,7 +809,10 @@ def run_analysis(domains_input: List[str], output_json: Optional[str] = None, ou
         )
         return analysis_result
 
-    with ThreadPoolExecutor() as executor:
+    # Cap concurrency to avoid spawning hundreds of threads (and hammering
+    # OCSP/CRL/crt.sh) when many domains are passed in.
+    max_workers = max(1, min(16, len(domains_input)))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
         results = list(executor.map(process_domain, domains_input))
 
     overall_end_time = datetime.datetime.now(timezone.utc)

--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -661,12 +661,16 @@ def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insec
         logger.info(f"Skipping OCSP check for {domain} as requested.")
         result["ocsp_check"]["checked"] = False
 
-    logger.info(f"Checking DNS CAA records for {domain}...")
-    try:
-        caa_info = query_caa(domain)
-        result["caa_check"].update(caa_info)
-    except Exception as e:
-        result["caa_check"].update({"checked": True, "found": False, "records": None, "error": str(e)})
+    if perform_caa_check:
+        logger.info(f"Checking DNS CAA records for {domain}...")
+        try:
+            caa_info = query_caa(domain)
+            result["caa_check"].update(caa_info)
+        except Exception as e:
+            result["caa_check"].update({"checked": True, "found": False, "records": None, "error": str(e)})
+    else:
+        logger.info(f"Skipping DNS CAA check for {domain} as requested.")
+        result["caa_check"]["checked"] = False
 
     # Certificate Transparency check (domain + parent domains)
     if not skip_transparency:

--- a/tests/test_tls_checker.py
+++ b/tests/test_tls_checker.py
@@ -241,7 +241,7 @@ def base_analyze(domain, port, insecure):
     return analyze_certificates(
         domain,
         port=port,
-        mode="leaf",
+        mode="simple",
         insecure=insecure,
         skip_transparency=True,
         perform_crl_check=False,

--- a/tests/test_tls_checker.py
+++ b/tests/test_tls_checker.py
@@ -18,7 +18,7 @@ def generate_self_signed_cert(common_name, san_list=None, not_before=None, not_a
     subject = issuer = x509.Name([
         x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, common_name),
     ])
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     not_before = not_before or (now - datetime.timedelta(days=1))
     not_after = not_after or (now + datetime.timedelta(days=1))
     builder = (
@@ -56,7 +56,7 @@ def generate_ca_cert(common_name="Test CA"):
     subject = issuer = x509.Name([
         x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, common_name),
     ])
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     builder = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -99,7 +99,7 @@ def generate_cert_signed_by_ca(ca_cert, ca_key, common_name, san_list=None, not_
     subject = x509.Name([
         x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, common_name),
     ])
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     not_before = not_before or (now - datetime.timedelta(days=1))
     not_after = not_after or (now + datetime.timedelta(days=1))
     builder = (
@@ -203,7 +203,7 @@ def test_fetch_leaf_certificate_host_mismatch_provides_details():
 
 def test_fetch_leaf_certificate_expired_cert_includes_details(monkeypatch):
     ca_cert, ca_key, ca_path = generate_ca_cert()
-    past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+    past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)
     cert, cert_path, key_path = generate_cert_signed_by_ca(
         ca_cert,
         ca_key,
@@ -315,7 +315,7 @@ def test_analyze_certificates_host_mismatch_propagates_error():
 
 def test_analyze_certificates_expired_certificate_propagates_error(monkeypatch):
     ca_cert, ca_key, ca_path = generate_ca_cert()
-    past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+    past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)
     cert, cert_path, key_path = generate_cert_signed_by_ca(
         ca_cert,
         ca_key,


### PR DESCRIPTION
## Summary

Four atomic fixes uncovered while auditing the codebase.

- **`fix(tls): respect perform_caa_check flag`** — `analyze_certificates` was always querying CAA records regardless of the flag; the boolean is now honored, with `caa_check.checked=False` when disabled (mirrors CRL/OCSP behavior).
- **`fix(tls): cap analysis thread pool`** — `ThreadPoolExecutor()` had no `max_workers`, allowing large bursts of outbound CRL/OCSP/crt.sh requests on big domain lists. Bounded to `min(16, len(domains))`.
- **`test(tls): use canonical mode value`** — tests passed `mode="leaf"` which the CLI doesn't accept. Aligned with `"simple"`.
- **`test(tls): replace deprecated datetime.utcnow`** — silences `DeprecationWarning` on Python 3.12+; future-proofs for removal.

## Test plan
- [x] `ALLOW_INTERNAL_IPS=true pytest tests/ -v` — 7/7 pass, 0 deprecation warnings.