### PR TITLE
fix(security): block SSRF redirect bypass on AIA/CRL/OCSP fetches

### DIFF
--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -13,11 +13,10 @@ from check_tls.utils.cert_utils import *
 from check_tls.utils.crl_utils import *
 from check_tls.utils.crtsh_utils import query_crtsh, query_crtsh_multi
 from check_tls.utils.dns_utils import query_caa
-from check_tls.utils.security_utils import validate_host_for_connection
+from check_tls.utils.security_utils import safe_http_fetch, validate_host_for_connection
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509.oid import ExtensionOID, ExtendedKeyUsageOID, AuthorityInformationAccessOID
-import urllib.request
 import json
 import os
 
@@ -226,8 +225,6 @@ def fetch_intermediate_certificates(cert: x509.Certificate) -> List[x509.Certifi
     Returns:
         List[x509.Certificate]: A list of intermediate certificates fetched from AIA URLs.
     """
-    import urllib.error  # Import here to fix type error and ensure availability
-
     logger = logging.getLogger("certcheck")
     intermediates = []
 
@@ -260,42 +257,40 @@ def fetch_intermediate_certificates(cert: x509.Certificate) -> List[x509.Certifi
             fetched_urls.add(url)
             logger.info(f"Fetching intermediate certificate from AIA URL: {url}")
 
+            # safe_http_fetch validates each hop (including redirects) against
+            # the SSRF allowlist and returns None on any failure, so a single
+            # except branch handles unexpected parse errors below.
+            response = safe_http_fetch(url)
+            if response is None:
+                logger.warning(f"Failed to fetch intermediate certificate from {url}")
+                continue
+
             try:
-                # Corrected urllib.request usage
-                req = urllib.request.Request(url, headers={'User-Agent': 'Python-CertCheck/1.3'})
-                with urllib.request.urlopen(req, timeout=10) as response:
-                    if response.status == 200:
-                        intermediate_der = response.read()
-                        content_type = response.info().get_content_type().lower()
-                        allowed_types = [
-                            'application/pkix-cert',
-                            'application/x-x509-ca-cert',
-                            'application/octet-stream',
-                            'application/pkcs7-mime'
-                        ]
-                        if any(allowed in content_type for allowed in allowed_types):
-                            try:
-                                # Detect PEM or DER format and load accordingly
-                                if b"-----BEGIN CERTIFICATE-----" in intermediate_der:
-                                    intermediate_cert = x509.load_pem_x509_certificate(intermediate_der, default_backend())
-                                else:
-                                    intermediate_cert = x509.load_der_x509_certificate(intermediate_der, default_backend())
-                                intermediates.append(intermediate_cert)
-                                logger.debug(f"Successfully loaded intermediate from {url}")
-                            except ValueError as e:
-                                logger.warning(f"Could not parse certificate data from {url}: {e}")
-                            except Exception as e:
-                                logger.warning(f"Unexpected error parsing certificate from {url}: {e}")
+                intermediate_der = response.content
+                content_type = (response.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+                allowed_types = [
+                    'application/pkix-cert',
+                    'application/x-x509-ca-cert',
+                    'application/octet-stream',
+                    'application/pkcs7-mime'
+                ]
+                if any(allowed in content_type for allowed in allowed_types):
+                    try:
+                        # Detect PEM or DER format and load accordingly
+                        if b"-----BEGIN CERTIFICATE-----" in intermediate_der:
+                            intermediate_cert = x509.load_pem_x509_certificate(intermediate_der, default_backend())
                         else:
-                            logger.warning(f"Unexpected content type '{content_type}' for intermediate certificate at {url}")
-                    else:
-                        logger.warning(f"Failed to fetch intermediate from {url}, status code: {response.status}")
-            except urllib.error.URLError as e:
-                logger.warning(f"Failed to fetch intermediate certificate from {url}: {e}")
-            except socket.timeout:
-                logger.warning(f"Timeout fetching intermediate certificate from {url}")
+                            intermediate_cert = x509.load_der_x509_certificate(intermediate_der, default_backend())
+                        intermediates.append(intermediate_cert)
+                        logger.debug(f"Successfully loaded intermediate from {url}")
+                    except ValueError as e:
+                        logger.warning(f"Could not parse certificate data from {url}: {e}")
+                    except Exception as e:
+                        logger.warning(f"Unexpected error parsing certificate from {url}: {e}")
+                else:
+                    logger.warning(f"Unexpected content type '{content_type}' for intermediate certificate at {url}")
             except Exception as e:
-                logger.warning(f"Unexpected error fetching intermediate certificate from {url}: {e}")
+                logger.warning(f"Unexpected error processing intermediate certificate from {url}: {e}")
 
     except x509.ExtensionNotFound:
         logger.info("No AIA extension found in the certificate to fetch intermediates.")

--- a/src/check_tls/utils/crl_utils.py
+++ b/src/check_tls/utils/crl_utils.py
@@ -5,16 +5,16 @@ Utility functions for downloading, parsing, and checking Certificate Revocation 
 Provides helpers to fetch CRLs from URIs, parse them, and check the revocation status of certificates.
 """
 
-import urllib.request
 import logging
 import datetime
 from datetime import timezone
-import socket
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509.oid import ExtensionOID, CRLEntryExtensionOID
 from typing import Optional, Dict, Any
 import urllib.parse
+
+from check_tls.utils.security_utils import safe_http_fetch
 
 # Timeout in seconds for CRL HTTP requests
 CRL_TIMEOUT = 10
@@ -23,6 +23,10 @@ CRL_TIMEOUT = 10
 def download_crl(url: str) -> Optional[bytes]:
     """
     Download a Certificate Revocation List (CRL) from the given URL.
+
+    The download is routed through :func:`safe_http_fetch` so the URL —
+    and any 3xx redirect target — is validated against the SSRF
+    allowlist before any bytes are read.
 
     Args:
         url (str): The URL to fetch the CRL from.
@@ -33,18 +37,10 @@ def download_crl(url: str) -> Optional[bytes]:
     Example:
         crl_data = download_crl("http://example.com/crl.pem")
     """
-    try:
-        req = urllib.request.Request(
-            url, headers={'User-Agent': 'Python-CertCheck/1.3'}
-        )
-        with urllib.request.urlopen(req, timeout=CRL_TIMEOUT) as response:
-            if response.status == 200:
-                return response.read()
-            else:
-                return None
-    except Exception as e:
-        # Could log the exception here if needed
+    response = safe_http_fetch(url, timeout=CRL_TIMEOUT)
+    if response is None:
         return None
+    return response.content
 
 
 def parse_crl(crl_data: bytes) -> Optional[x509.CertificateRevocationList]:

--- a/src/check_tls/utils/ocsp_utils.py
+++ b/src/check_tls/utils/ocsp_utils.py
@@ -7,11 +7,12 @@ checks for X.509 certificates.
 """
 from typing import Any, Dict, List, Optional
 
-import requests
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.x509 import ocsp
 from cryptography.x509.oid import AuthorityInformationAccessOID, ExtensionOID # Import ExtensionOID
+
+from check_tls.utils.security_utils import safe_http_fetch
 
 
 def get_ocsp_urls(cert: x509.Certificate) -> List[str]:
@@ -95,16 +96,19 @@ def fetch_ocsp_response(url: str, request_data: bytes) -> Optional[bytes]:
         >>> #     print("Failed to fetch OCSP response.")
         OCSP response received. # Or Failed to fetch OCSP response.
     """
-    try:
-        headers = {"Content-Type": "application/ocsp-request"}
-        response = requests.post(url, data=request_data, headers=headers, timeout=10)
-        response.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
-        if response.status_code == 200:
-            return response.content
-    except requests.exceptions.RequestException:
-        # Covers connection errors, timeouts, HTTP errors, etc.
-        pass
-    return None
+    headers = {"Content-Type": "application/ocsp-request"}
+    response = safe_http_fetch(
+        url,
+        method="POST",
+        data=request_data,
+        headers=headers,
+        timeout=10,
+    )
+    if response is None:
+        # safe_http_fetch already logged the failure reason (SSRF block,
+        # transport error, non-2xx, or too many redirects).
+        return None
+    return response.content
 
 
 def parse_ocsp_response(data: bytes) -> Dict[str, Any]:

--- a/src/check_tls/utils/security_utils.py
+++ b/src/check_tls/utils/security_utils.py
@@ -6,9 +6,13 @@ Provides functions to validate domains and IP addresses before making connection
 """
 
 import ipaddress
+import os
 import socket
 import logging
-from typing import Tuple, Optional
+from typing import Tuple, Optional, Dict
+from urllib.parse import urljoin, urlparse
+
+import requests
 
 
 # Private/internal IP ranges that should be blocked to prevent SSRF attacks
@@ -172,3 +176,203 @@ def is_port_allowed(port: int, allowed_ports: Optional[set] = None) -> Tuple[boo
         return True, None
     else:
         return False, f"Port {port} is not in the allowed list: {sorted(allowed_ports)}"
+
+
+# Default User-Agent applied to safe_http_fetch when callers do not override it.
+_DEFAULT_USER_AGENT = "Python-CertCheck/1.3"
+
+# Schemes that safe_http_fetch is allowed to dispatch.
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+def _allow_internal_ips_from_env() -> bool:
+    """
+    Read the ``ALLOW_INTERNAL_IPS`` environment variable.
+
+    Returns
+    -------
+    bool
+        ``True`` when the environment variable is set to ``"true"``
+        (case-insensitive), ``False`` otherwise. Defaults to ``False``
+        so SSRF protection is the default posture.
+    """
+    return os.getenv("ALLOW_INTERNAL_IPS", "false").lower() == "true"
+
+
+def safe_http_fetch(
+    url: str,
+    *,
+    method: str = "GET",
+    data: Optional[bytes] = None,
+    headers: Optional[Dict[str, str]] = None,
+    timeout: float = 10.0,
+    max_redirects: int = 5,
+) -> Optional[requests.Response]:
+    """
+    Issue an HTTP(S) request with per-hop SSRF validation and manual redirect handling.
+
+    The function performs the following checks before each network hop
+    (initial URL plus every redirect target) to prevent SSRF attacks
+    that abuse 3xx responses to pivot to internal addresses:
+
+    * the URL must use the ``http`` or ``https`` scheme;
+    * the host must pass :func:`validate_host_for_connection`, honoring
+      the ``ALLOW_INTERNAL_IPS`` environment variable;
+    * automatic redirect following provided by :mod:`requests` is
+      disabled — redirects are followed manually up to ``max_redirects``
+      hops, with the same validation re-applied for each ``Location``.
+
+    Any failure (validation, transport error, non-2xx after redirects,
+    too many redirects, malformed redirect target) results in ``None``,
+    so call sites can keep treating fetch failures as soft errors —
+    matching the previous behavior of the migrated callers.
+
+    Parameters
+    ----------
+    url : str
+        The absolute URL to fetch. Must use ``http`` or ``https``.
+    method : str, optional
+        HTTP method to use. Only ``"GET"`` and ``"POST"`` are expected
+        by the current callers; other methods are passed through to
+        :mod:`requests` unchanged. Defaults to ``"GET"``.
+    data : bytes, optional
+        Optional request body, forwarded as-is to :mod:`requests`.
+    headers : dict[str, str], optional
+        Optional HTTP headers. A default ``User-Agent`` is added when
+        the caller does not provide one.
+    timeout : float, optional
+        Per-request timeout in seconds, applied to every hop.
+        Defaults to ``10.0``.
+    max_redirects : int, optional
+        Maximum number of 3xx hops to follow. Defaults to ``5``.
+
+    Returns
+    -------
+    requests.Response or None
+        The successful response on the final hop, or ``None`` when any
+        hop is rejected, errors out, or the chain exceeds
+        ``max_redirects``.
+
+    Examples
+    --------
+    >>> # Block direct connection to a private IP
+    >>> safe_http_fetch("http://127.0.0.1/")  # doctest: +SKIP
+    None
+
+    >>> # Reject non-HTTP schemes outright
+    >>> safe_http_fetch("file:///etc/passwd")  # doctest: +SKIP
+    None
+    """
+    logger = logging.getLogger("certcheck")
+
+    # Normalize headers and apply a default User-Agent so call sites
+    # do not need to repeat it; preserve any caller-provided override.
+    request_headers: Dict[str, str] = dict(headers or {})
+    if not any(name.lower() == "user-agent" for name in request_headers):
+        request_headers["User-Agent"] = _DEFAULT_USER_AGENT
+
+    allow_private = _allow_internal_ips_from_env()
+    method_upper = method.upper()
+    current_url = url
+
+    for hop in range(max_redirects + 1):
+        parsed = urlparse(current_url)
+        if parsed.scheme not in _ALLOWED_SCHEMES:
+            logger.warning(
+                "safe_http_fetch: refusing non-HTTP(S) URL '%s' (scheme=%r)",
+                current_url,
+                parsed.scheme,
+            )
+            return None
+
+        host = parsed.hostname
+        if not host:
+            logger.warning("safe_http_fetch: URL '%s' has no hostname", current_url)
+            return None
+
+        # Determine the effective port for the validation step. Fall back
+        # to the scheme default when the URL does not pin one explicitly.
+        try:
+            port = parsed.port if parsed.port is not None else (
+                443 if parsed.scheme == "https" else 80
+            )
+        except ValueError:
+            logger.warning("safe_http_fetch: URL '%s' has an invalid port", current_url)
+            return None
+
+        is_valid, validation_error = validate_host_for_connection(
+            host, port, allow_private_ips=allow_private
+        )
+        if not is_valid:
+            logger.warning(
+                "safe_http_fetch: blocked %s '%s' - %s",
+                "redirect to" if hop > 0 else "request to",
+                current_url,
+                validation_error,
+            )
+            return None
+
+        try:
+            response = requests.request(
+                method_upper,
+                current_url,
+                data=data,
+                headers=request_headers,
+                timeout=timeout,
+                allow_redirects=False,
+            )
+        except requests.exceptions.RequestException as exc:
+            logger.warning(
+                "safe_http_fetch: transport error fetching '%s': %s",
+                current_url,
+                exc,
+            )
+            return None
+
+        # Follow 3xx redirects manually so we can re-validate each hop.
+        if response.is_redirect or response.status_code in (301, 302, 303, 307, 308):
+            location = response.headers.get("Location")
+            if not location:
+                logger.warning(
+                    "safe_http_fetch: %s response from '%s' had no Location header",
+                    response.status_code,
+                    current_url,
+                )
+                return None
+
+            # Resolve relative redirects against the current URL.
+            next_url = urljoin(current_url, location)
+            logger.debug(
+                "safe_http_fetch: redirect %s -> '%s' (hop %d)",
+                response.status_code,
+                next_url,
+                hop + 1,
+            )
+
+            # RFC 7231: 303 forces GET; 301/302 historically behave the
+            # same way for cross-method redirects in the wild. 307/308
+            # preserve method and body. We err on the safe side and only
+            # preserve method/body for 307/308.
+            if response.status_code in (301, 302, 303):
+                method_upper = "GET"
+                data = None
+
+            current_url = next_url
+            continue
+
+        if not response.ok:
+            logger.warning(
+                "safe_http_fetch: non-success status %d from '%s'",
+                response.status_code,
+                current_url,
+            )
+            return None
+
+        return response
+
+    logger.warning(
+        "safe_http_fetch: exceeded max_redirects=%d starting from '%s'",
+        max_redirects,
+        url,
+    )
+    return None

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -1,0 +1,285 @@
+"""
+test_security_utils.py
+
+Regression coverage for the SSRF protections in
+:mod:`check_tls.utils.security_utils`. The tests focus on
+:func:`safe_http_fetch` because it is the only entry point the AIA,
+CRL and OCSP fetchers go through after the SSRF-redirect-bypass fix.
+
+The pytest suite is launched with ``ALLOW_INTERNAL_IPS=true`` so
+loopback test fixtures can serve traffic. Tests that need to *prove*
+a private-IP target is rejected scope the environment variable back
+to ``"false"`` for the duration of the test via
+:func:`pytest.MonkeyPatch.setenv`. For the redirect-target test we
+instead monkeypatch :func:`validate_host_for_connection` so the first
+hop to the test server is allowed but loopback redirect targets are
+still refused — that precisely models the threat: the
+AIA/CRL/OCSP server is "trusted" but its 302 points at
+``169.254.169.254`` / ``127.0.0.1``.
+"""
+
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Callable, List, Tuple
+
+import pytest
+
+from check_tls.utils import security_utils
+from check_tls.utils.security_utils import safe_http_fetch
+
+
+def _start_http_server(
+    handler_factory: Callable[[List[Tuple[str, str]]], type],
+) -> Tuple[HTTPServer, List[Tuple[str, str]], Callable[[], None]]:
+    """
+    Start an in-process HTTP server bound to ``127.0.0.1`` on an ephemeral port.
+
+    Parameters
+    ----------
+    handler_factory : Callable
+        Factory taking the shared request log list and returning a
+        :class:`http.server.BaseHTTPRequestHandler` subclass.
+
+    Returns
+    -------
+    tuple
+        ``(server, request_log, stop)`` where ``server`` is the live
+        :class:`HTTPServer`, ``request_log`` is a list mutated by the
+        handler (one ``(method, path)`` tuple per served request), and
+        ``stop`` is a callable that shuts the server down and joins
+        the serving thread.
+    """
+    request_log: List[Tuple[str, str]] = []
+    handler_cls = handler_factory(request_log)
+    server = HTTPServer(("127.0.0.1", 0), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    def stop() -> None:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    return server, request_log, stop
+
+
+def _ok_handler_factory(request_log: List[Tuple[str, str]]) -> type:
+    """Build a handler that replies ``200 OK`` with a fixed body."""
+
+    class _OkHandler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args) -> None:  # noqa: A002
+            return
+
+        def _serve(self) -> None:
+            request_log.append((self.command, self.path))
+            body = b"ok"
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self) -> None:  # noqa: N802
+            self._serve()
+
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0") or 0)
+            if length:
+                self.rfile.read(length)
+            self._serve()
+
+    return _OkHandler
+
+
+def _redirect_handler_factory(target_url: str) -> Callable[[List[Tuple[str, str]]], type]:
+    """Return a factory that builds a 302-redirect handler pointing at ``target_url``."""
+
+    def factory(request_log: List[Tuple[str, str]]) -> type:
+        class _RedirectHandler(BaseHTTPRequestHandler):
+            def log_message(self, format: str, *args) -> None:  # noqa: A002
+                return
+
+            def do_GET(self) -> None:  # noqa: N802
+                request_log.append((self.command, self.path))
+                self.send_response(302)
+                self.send_header("Location", target_url)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+        return _RedirectHandler
+
+    return factory
+
+
+def _chain_factory(
+    state: dict,
+) -> Callable[[List[Tuple[str, str]]], type]:
+    """
+    Build a handler that walks ``state['chain']`` of redirect Locations.
+
+    The handler reads the chain list from a shared mutable ``state``
+    dict so the caller can rewrite the absolute URLs once the server
+    port is known.
+    """
+
+    def factory(request_log: List[Tuple[str, str]]) -> type:
+        class _ChainHandler(BaseHTTPRequestHandler):
+            def log_message(self, format: str, *args) -> None:  # noqa: A002
+                return
+
+            def do_GET(self) -> None:  # noqa: N802
+                request_log.append((self.command, self.path))
+                idx = state["index"]
+                chain = state["chain"]
+                if idx < len(chain):
+                    state["index"] = idx + 1
+                    self.send_response(302)
+                    self.send_header("Location", chain[idx])
+                    self.send_header("Content-Length", "0")
+                    self.end_headers()
+                    return
+                body = b"final"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        return _ChainHandler
+
+    return factory
+
+
+def test_safe_http_fetch_rejects_direct_private_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Initial URL pointing at 127.0.0.1 must be blocked when SSRF guard is active."""
+    # Force the guard back on for this test even though the suite runs
+    # with ALLOW_INTERNAL_IPS=true.
+    monkeypatch.setenv("ALLOW_INTERNAL_IPS", "false")
+
+    # Bind a server but never expect it to be hit; safe_http_fetch must
+    # short-circuit before any socket connection to the loopback target.
+    server, request_log, stop = _start_http_server(_ok_handler_factory)
+    port = server.server_address[1]
+    try:
+        result = safe_http_fetch(f"http://127.0.0.1:{port}/")
+        assert result is None
+        assert request_log == [], "server should never have been contacted"
+    finally:
+        stop()
+
+
+def test_safe_http_fetch_rejects_redirect_to_private_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A 302 from an allowed first hop pointing at a private IP must be refused.
+
+    The historic SSRF bypass was exactly this: the initial URL passes
+    the allowlist but the redirect target is a metadata / loopback
+    address. We monkeypatch :func:`validate_host_for_connection` so
+    the first hop is allowed and the loopback redirect target is
+    rejected — proving ``safe_http_fetch`` re-validates each hop.
+    """
+    # Redirect to a clearly internal address that is never bound.
+    blocked_target = "http://169.254.169.254/latest/meta-data/"
+    server, request_log, stop = _start_http_server(
+        _redirect_handler_factory(blocked_target)
+    )
+    port = server.server_address[1]
+
+    real_validate = security_utils.validate_host_for_connection
+
+    def selective_validate(host, p, allow_private_ips=False):
+        # Allow only the test server's host:port; everything else goes
+        # through the real (strict) validator regardless of the env.
+        if host == "127.0.0.1" and p == port:
+            return True, None
+        return real_validate(host, p, allow_private_ips=False)
+
+    monkeypatch.setattr(
+        security_utils,
+        "validate_host_for_connection",
+        selective_validate,
+    )
+
+    try:
+        result = safe_http_fetch(f"http://127.0.0.1:{port}/")
+        assert result is None
+        # Initial hop was made; the redirect was inspected and rejected
+        # before being followed, so only one request hits the wire.
+        assert request_log == [("GET", "/")]
+    finally:
+        stop()
+
+
+def test_safe_http_fetch_follows_allowed_redirect_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multi-hop redirect chain entirely on the allowlist should succeed."""
+    # Suite-level ALLOW_INTERNAL_IPS=true is enough; pin it for clarity.
+    monkeypatch.setenv("ALLOW_INTERNAL_IPS", "true")
+
+    state = {"index": 0, "chain": []}
+    server, request_log, stop = _start_http_server(_chain_factory(state))
+    port = server.server_address[1]
+    state["chain"] = [
+        f"http://127.0.0.1:{port}/step2",
+        f"http://127.0.0.1:{port}/step3",
+    ]
+    try:
+        result = safe_http_fetch(f"http://127.0.0.1:{port}/start")
+        assert result is not None
+        assert result.status_code == 200
+        assert result.content == b"final"
+        # Three hops total: /start -> /step2 -> /step3.
+        paths = [path for _method, path in request_log]
+        assert paths == ["/start", "/step2", "/step3"]
+    finally:
+        stop()
+
+
+def test_safe_http_fetch_max_redirects_exceeded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A redirect loop deeper than ``max_redirects`` must yield ``None``."""
+    monkeypatch.setenv("ALLOW_INTERNAL_IPS", "true")
+
+    def factory(request_log: List[Tuple[str, str]]) -> type:
+        class _LoopHandler(BaseHTTPRequestHandler):
+            def log_message(self, format: str, *args) -> None:  # noqa: A002
+                return
+
+            def do_GET(self) -> None:  # noqa: N802
+                request_log.append((self.command, self.path))
+                self.send_response(302)
+                self.send_header("Location", "/loop")
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+        return _LoopHandler
+
+    server, request_log, stop = _start_http_server(factory)
+    port = server.server_address[1]
+    try:
+        result = safe_http_fetch(
+            f"http://127.0.0.1:{port}/loop",
+            max_redirects=2,
+        )
+        assert result is None
+        # Initial request + 2 redirect follow-ups = 3 entries on the wire.
+        assert len(request_log) == 3
+    finally:
+        stop()
+
+
+def test_safe_http_fetch_rejects_non_http_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non HTTP(S) schemes must be rejected before any I/O happens."""
+    monkeypatch.setenv("ALLOW_INTERNAL_IPS", "true")
+
+    assert safe_http_fetch("file:///etc/passwd") is None
+    assert safe_http_fetch("ftp://example.com/foo") is None
+    assert safe_http_fetch("gopher://example.com/0/x") is None


### PR DESCRIPTION
## Vulnerability

`check-tls` already validated the **initial** TLS connection against
`security_utils.validate_host_for_connection`, but the subsequent
HTTP fetches that consume URLs *from the certificate itself* —
intermediate AIA fetch (`urllib.request.urlopen`), CRL download
(`urllib.request.urlopen`) and OCSP request (`requests.post`) —
followed 3xx redirects transparently and never re-validated the
target host. An attacker controlling the cert (or any of its
AIA/CRL/OCSP responders) could return a 302 pointing at
`http://169.254.169.254/...` (cloud metadata),
`http://127.0.0.1:.../`, or any RFC1918 address, and the tool would
gladly follow. This affected every CLI run and every call to the
public `/api/analyze` endpoint.

## Fix

Add a single `safe_http_fetch` helper in
`src/check_tls/utils/security_utils.py` that:

- only accepts `http` / `https` URLs;
- runs `validate_host_for_connection` on the **initial host and
  every redirect target**, honoring `ALLOW_INTERNAL_IPS`;
- disables `requests`' transparent redirect following and
  re-issues each hop manually, capped by `max_redirects` (default
  5); rewrites the method to GET on 301/302/303 and preserves
  method/body on 307/308;
- treats all failures (validation, transport, non-2xx, redirect
  loops, malformed `Location`) as soft errors returning `None`,
  matching what the migrated callers already expect.

The three call sites (`tls_checker.fetch_intermediate_certificates`,
`crl_utils.download_crl`, `ocsp_utils.fetch_ocsp_response`) now go
through this fetcher exclusively. `urllib.request` is removed from
the call sites for consistency.

A judgment call: 301/302/303 redirects rewrite the method to GET and
drop the body. RFC 7231 is ambiguous in the wild, and erring on the
strict side avoids leaking an OCSP DER blob to a redirect target.
307/308 keep method and body as the RFC requires.

## Test plan

`ALLOW_INTERNAL_IPS=true uv run pytest tests/ -v` — 12 passed.

- [x] `test_safe_http_fetch_rejects_direct_private_ip` — direct
  `http://127.0.0.1:NNN/` returns `None` and the local server
  records zero requests (env flipped to `false` for the test).
- [x] `test_safe_http_fetch_rejects_redirect_to_private_ip` — local
  server returns `302 Location: http://169.254.169.254/...`;
  `validate_host_for_connection` is monkeypatched to allow only the
  test server's `host:port`. The call returns `None` and the test
  server records exactly one request (the redirect was inspected
  and rejected, never followed).
- [x] `test_safe_http_fetch_follows_allowed_redirect_chain` —
  3-hop chain on loopback succeeds; the test asserts on the
  observed request paths to prove every hop was actually walked.
- [x] `test_safe_http_fetch_max_redirects_exceeded` —
  `max_redirects=2` against a self-redirect loop returns `None`
  after exactly 3 wire requests.
- [x] `test_safe_http_fetch_rejects_non_http_scheme` — `file://`,
  `ftp://`, `gopher://` all return `None` with no I/O.

Pre-existing TLS regression tests (hostname mismatch, expired,
wildcard SAN handling, …) continue to pass.

`uv run --with ruff ruff check src/ tests/` — same 20 pre-existing
errors as `main` (wildcard-import F405 etc.). The new file
(`tests/test_security_utils.py`) is clean.