### PR TITLE
fix(web): harden Flask app (XSS + security headers)

### DIFF
--- a/src/check_tls/web_server.py
+++ b/src/check_tls/web_server.py
@@ -51,6 +51,59 @@ def get_flask_app():
                 static_folder=os.path.join(project_root, 'static'))
     app.config['SCRIPT_ARGS'] = argparse.Namespace(insecure=False, no_transparency=False, no_crl_check=False, no_caa_check=False, connect_port=443)
 
+    @app.after_request
+    def _set_security_headers(response):
+        """
+        Attach security-related HTTP response headers to every response.
+
+        Applied via ``after_request`` so the headers are present for both
+        the HTML UI and the JSON API, and also when the app is served by a
+        WSGI server instead of Flask's built-in server.
+
+        Headers set (using ``setdefault`` so a downstream proxy can override):
+
+        * ``X-Content-Type-Options: nosniff`` — prevents MIME-type sniffing.
+        * ``X-Frame-Options: DENY`` — blocks clickjacking via iframes.
+        * ``Referrer-Policy: no-referrer`` — suppresses the Referer header.
+        * ``Content-Security-Policy`` — restricts resource loading:
+
+          - Scripts: ``'self'`` + ``cdn.jsdelivr.net`` (Bootstrap bundle).
+            ``'unsafe-inline'`` is **not** included because the HTML template
+            contains no inline ``<script>`` blocks.
+          - Styles: ``'self'`` + ``cdn.jsdelivr.net`` (Bootstrap CSS) +
+            ``fonts.googleapis.com`` (Google Fonts CSS).  ``'unsafe-inline'``
+            is kept because Bootstrap's JavaScript injects inline ``style``
+            attributes at runtime (tooltip positioning, collapse, etc.).
+          - Fonts: ``'self'`` + ``fonts.gstatic.com`` (Inter typeface files).
+          - Images: ``'self' data:`` (Bootstrap uses data-URIs for some icons).
+          - Frames: ``frame-ancestors 'none'`` — redundant with X-Frame-Options
+            but respected by modern browsers.
+
+        Parameters
+        ----------
+        response : flask.Response
+            The outgoing Flask response object.
+
+        Returns
+        -------
+        flask.Response
+            The same response object with the security headers attached.
+        """
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "no-referrer")
+        response.headers.setdefault(
+            "Content-Security-Policy",
+            "default-src 'self'; "
+            "script-src 'self' https://cdn.jsdelivr.net; "
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; "
+            "font-src 'self' https://fonts.gstatic.com; "
+            "img-src 'self' data:; "
+            "connect-src 'self'; "
+            "frame-ancestors 'none'",
+        )
+        return response
+
     @app.route('/', methods=['GET'])
     def index():
         """

--- a/src/check_tls/web_server.py
+++ b/src/check_tls/web_server.py
@@ -5,20 +5,30 @@ import os # Added for path manipulation
 from urllib.parse import urlparse  # Added for URL parsing
 from flask import Flask, render_template, request, jsonify, current_app
 from check_tls.tls_checker import analyze_certificates
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 
 def get_tooltip(text):
     """
-    Generate a Bootstrap tooltip icon with the given text.
+    Render a Bootstrap tooltip icon with HTML-escaped tooltip text.
 
-    Args:
-        text (str): The tooltip text to display on hover.
+    Uses ``Markup.format`` so the argument is auto-escaped by markupsafe,
+    preventing XSS injection through the ``title`` attribute.
 
-    Returns:
-        Markup: A Markup string containing the HTML for the tooltip icon.
+    Parameters
+    ----------
+    text : str
+        The tooltip text to display on hover.  May contain arbitrary
+        characters; they will be HTML-escaped before insertion.
+
+    Returns
+    -------
+    Markup
+        A ``Markup`` string containing the safe HTML for the tooltip icon.
     """
-    return Markup(f"<span data-bs-toggle='tooltip' data-bs-placement='top' title='{text}'>🛈</span>")
+    return Markup(
+        '<span data-bs-toggle="tooltip" data-bs-placement="top" title="{}">🛈</span>'
+    ).format(escape(text))
 
 
 def get_flask_app():

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,0 +1,146 @@
+"""Tests for web_server hardening: tooltip XSS escaping and security headers."""
+import pytest
+from markupsafe import Markup
+from check_tls.web_server import get_tooltip, get_flask_app
+
+
+# ---------------------------------------------------------------------------
+# get_tooltip – XSS escaping
+# ---------------------------------------------------------------------------
+
+class TestGetTooltip:
+    """Verify that get_tooltip safely escapes its argument."""
+
+    def test_returns_markup_instance(self):
+        """Return value must be a Markup so Jinja2 won't double-escape it."""
+        result = get_tooltip("hello")
+        assert isinstance(result, Markup)
+
+    def test_plain_text_round_trips(self):
+        """Plain ASCII text should appear unchanged inside the title attribute."""
+        result = get_tooltip("some text")
+        assert 'title="some text"' in result
+
+    def test_script_tag_escaped(self):
+        """
+        A ``<script>`` payload must be HTML-escaped so it cannot execute.
+
+        Passing ``'<script>alert(1)</script>'`` must produce ``&lt;script&gt;``
+        in the rendered output, never a raw ``<script>`` tag.
+        """
+        payload = "<script>alert(1)</script>"
+        result = get_tooltip(payload)
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result
+
+    def test_quote_injection_escaped(self):
+        """
+        A payload designed to break out of the title attribute must be escaped.
+
+        ``'" onload="x'`` would close the attribute and inject an event handler
+        if not properly escaped.  The double-quote must appear as ``&#34;`` or
+        ``&quot;`` — never as a raw ``"`` that could terminate the attribute.
+        """
+        payload = '" onload="x'
+        result = get_tooltip(payload)
+        # The rendered title="..." must not contain an unescaped closing quote
+        # that would allow attribute break-out.  markupsafe escapes " as &#34;.
+        assert '" onload="' not in result
+        # The escaped form should be present somewhere in the output.
+        assert "&#34;" in result or "&quot;" in result
+
+    def test_ampersand_escaped(self):
+        """Ampersands must be escaped to ``&amp;``."""
+        result = get_tooltip("a & b")
+        assert "&amp;" in result
+        # Raw unescaped ampersand must not appear inside the attribute value
+        assert "title=\"a & b\"" not in result
+
+
+# ---------------------------------------------------------------------------
+# Security headers – HTML page
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def flask_client():
+    """Provide a Flask test client for the full app."""
+    app = get_flask_app()
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+class TestSecurityHeadersOnIndex:
+    """Security headers must be present on GET /."""
+
+    def test_x_content_type_options(self, flask_client):
+        """X-Content-Type-Options must be 'nosniff'."""
+        response = flask_client.get("/")
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+
+    def test_x_frame_options(self, flask_client):
+        """X-Frame-Options must be 'DENY'."""
+        response = flask_client.get("/")
+        assert response.headers.get("X-Frame-Options") == "DENY"
+
+    def test_referrer_policy(self, flask_client):
+        """Referrer-Policy must be 'no-referrer'."""
+        response = flask_client.get("/")
+        assert response.headers.get("Referrer-Policy") == "no-referrer"
+
+    def test_content_security_policy_present(self, flask_client):
+        """Content-Security-Policy header must be set."""
+        response = flask_client.get("/")
+        csp = response.headers.get("Content-Security-Policy", "")
+        assert csp, "Content-Security-Policy header is missing"
+
+    def test_csp_contains_default_src_self(self, flask_client):
+        """CSP must include a default-src directive."""
+        response = flask_client.get("/")
+        csp = response.headers.get("Content-Security-Policy", "")
+        assert "default-src 'self'" in csp
+
+    def test_csp_contains_frame_ancestors_none(self, flask_client):
+        """CSP must include frame-ancestors 'none' to block framing."""
+        response = flask_client.get("/")
+        csp = response.headers.get("Content-Security-Policy", "")
+        assert "frame-ancestors 'none'" in csp
+
+
+# ---------------------------------------------------------------------------
+# Security headers – API error response
+# ---------------------------------------------------------------------------
+
+class TestSecurityHeadersOnApiError:
+    """Security headers must also be present on API error responses."""
+
+    def test_headers_on_non_json_request(self, flask_client):
+        """
+        POST /api/analyze with non-JSON body returns 400 but must still carry
+        all four security headers.
+        """
+        response = flask_client.post(
+            "/api/analyze",
+            data="not json",
+            content_type="text/plain",
+        )
+        assert response.status_code == 400
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("Referrer-Policy") == "no-referrer"
+        assert response.headers.get("Content-Security-Policy")
+
+    def test_headers_on_missing_domains_field(self, flask_client):
+        """
+        POST /api/analyze with JSON body lacking 'domains' returns 400 but
+        must still carry all four security headers.
+        """
+        response = flask_client.post(
+            "/api/analyze",
+            json={},
+        )
+        assert response.status_code == 400
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("Referrer-Policy") == "no-referrer"
+        assert response.headers.get("Content-Security-Policy")


### PR DESCRIPTION
## Vulnerability summary

1. **XSS foot-gun in `get_tooltip`** — the helper built a `Markup` string
   via an f-string, meaning any caller that passed user-controlled or
   partially-templated content would bypass Jinja2 auto-escaping and inject
   arbitrary HTML/JavaScript through the `title` attribute.

2. **No security response headers** — the Flask app emitted no
   `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`,
   or `Referrer-Policy` headers, leaving browsers with no guidance on
   permitted resource origins and enabling clickjacking.

## Fix summary

* **`fix(web): escape tooltip text to prevent XSS`** — switched
  `get_tooltip()` from `Markup(f"...{text}...")` to
  `Markup("...{}...").format(escape(text))` so markupsafe HTML-encodes the
  argument before it reaches the `title` attribute.  No functional change for
  callers that already pass literal strings.

* **`feat(web): add security response headers (CSP, X-Frame-Options, etc.)`**
  — added an `@app.after_request` handler in `get_flask_app()` (not in
  `run_server`, so headers apply under WSGI too) that attaches four headers
  to every response via `setdefault` (reverse-proxy-overridable):
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: DENY`
  - `Referrer-Policy: no-referrer`
  - `Content-Security-Policy` tailored to what the UI actually loads:
    Bootstrap and Google Fonts from their CDNs, local static files for
    everything else.  `'unsafe-inline'` is retained for `style-src` only
    because Bootstrap's JS injects inline `style` attributes at runtime;
    `script-src` carries no `'unsafe-inline'` since the template has no
    inline `<script>` blocks.

* **`test(web): cover tooltip escaping and security headers`** — new
  `tests/test_web_server.py` with 13 tests across three classes (see test
  plan below).

## Test plan

- [x] `TestGetTooltip::test_returns_markup_instance` — return type is `Markup`
- [x] `TestGetTooltip::test_plain_text_round_trips` — plain ASCII unchanged
- [x] `TestGetTooltip::test_script_tag_escaped` — `<script>` → `&lt;script&gt;`
- [x] `TestGetTooltip::test_quote_injection_escaped` — `"` → `&#34;`/`&quot;`
- [x] `TestGetTooltip::test_ampersand_escaped` — `&` → `&amp;`
- [x] `TestSecurityHeadersOnIndex::test_x_content_type_options`
- [x] `TestSecurityHeadersOnIndex::test_x_frame_options`
- [x] `TestSecurityHeadersOnIndex::test_referrer_policy`
- [x] `TestSecurityHeadersOnIndex::test_content_security_policy_present`
- [x] `TestSecurityHeadersOnIndex::test_csp_contains_default_src_self`
- [x] `TestSecurityHeadersOnIndex::test_csp_contains_frame_ancestors_none`
- [x] `TestSecurityHeadersOnApiError::test_headers_on_non_json_request`
- [x] `TestSecurityHeadersOnApiError::test_headers_on_missing_domains_field`

All 20 tests pass (`uv run pytest tests/ -v`). No new ruff errors introduced.