### PR TITLE
chore(repo): hygiene pass (build/, uv.lock, .dockerignore, HEALTHCHECK)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ __pycache__/
 *.pytest_cache/
 
 # Ignore virtual environments
+.venv/
 venv/
 .env/
 .envrc
@@ -18,9 +19,15 @@ build/
 .eggs/
 *.egg-info/
 
-# Ignore git and editor files
+# Ignore tests (not needed in the runtime image)
+tests/
+
+# Ignore git and CI/CD metadata
 .git/
+.github/
 .gitignore
+
+# Ignore editor and OS files
 *.swp
 *.swo
 *.bak
@@ -30,9 +37,22 @@ build/
 *.env
 secrets.*
 
-# Ignore docs and markdown previews
+# Ignore docs and markdown previews (none needed in the runtime image)
 *.md~
+*.md
+
+# Ignore screenshots
+screenshot_*.png
 
 # Ignore Docker artifacts
 Dockerfile*
 .dockerignore
+
+# Ignore worktree directories
+.worktrees/
+
+# Ignore Claude/OMC AI tooling config
+.claude/
+.omc/
+CLAUDE.md
+AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 check_tls.egg-info
 .history
 .DS_Store
+uv.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,11 @@ EXPOSE 8000
 
 ENTRYPOINT ["check-tls"]
 
+# Healthcheck only meaningful when run with `--server`. For the default CLI
+# entrypoint the container exits quickly and the healthcheck is a no-op.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD wget --quiet --tries=1 --spider http://localhost:8000/ || exit 1
+
 # Metadata Labels - ensure APP_VERSION is correctly interpolated
 LABEL org.opencontainers.image.title="Check TLS Bundle" \
       org.opencontainers.image.description="A versatile Python tool to analyze TLS/SSL certificates for one or multiple domains, featuring profile detection, chain validation, and multiple output formats. Includes a handy web interface mode!" \


### PR DESCRIPTION
## What changed and why

This PR applies four hygiene fixes to clean up repo/image debt:

- **Fix 1 (build/)**: Already clean — `build/` was not tracked and already listed in `.gitignore`. No action needed.
- **Fix 2 (uv.lock)**: Project uses `setuptools`/`pip` as build backend (no `[tool.uv]` config). `uv.lock` is a dev-environment side effect with no reproducibility value here. Added to `.gitignore` to prevent accidental commits.
- **Fix 3 (.dockerignore)**: A `.dockerignore` already existed but was missing several entries. Expanded to cover `.venv/`, `tests/`, `.github/`, `screenshot_*.png`, `*.md`, `.worktrees/`, and AI tooling dirs (`.claude/`, `.omc/`, `CLAUDE.md`, `AGENTS.md`). The Dockerfile only needs `pyproject.toml` + `src/` — everything else is extraneous build context.
- **Fix 4 (HEALTHCHECK)**: Added `HEALTHCHECK` to the Dockerfile using `wget` (available via BusyBox in `python:3.13-alpine`, no extra package install needed). The check probes `http://localhost:8000/` which is only meaningful when the container runs with `--server`; for the default CLI entrypoint the container exits before the healthcheck fires.

## Per-fix commits

- `4f31345` chore(repo): ignore uv.lock — adds `uv.lock` to `.gitignore`; project is setuptools-based
- `76e6852` chore(docker): expand .dockerignore to cover more build context noise — adds `.venv/`, `tests/`, `.github/`, screenshots, `*.md`, `.worktrees/`, AI tooling dirs
- `ea03380` chore(docker): add HEALTHCHECK for server mode — uses `wget --spider` on port 8000; no-op for CLI use

## Test plan

- [x] `ALLOW_INTERNAL_IPS=true uv run pytest tests/ -v` → 7 passed, 0 failed (run after each commit)
- [x] `docker build --build-arg APP_VERSION=0.0.0 -t check-tls-hygiene-test .` → build succeeds with HEALTHCHECK instruction visible in output
- [x] `wget` confirmed available in `python:3.13-alpine` (BusyBox v1.37.0) — no extra package install required