### PR TITLE
chore(crtsh): user-agent from version + configurable rate limit

### DIFF
--- a/src/check_tls/utils/crtsh_utils.py
+++ b/src/check_tls/utils/crtsh_utils.py
@@ -5,16 +5,35 @@ Utility functions for querying crt.sh for certificate transparency logs.
 Provides helpers to fetch certificate data for a domain and its parent domains.
 """
 
+import os
 import urllib.request
 import urllib.error
 import json
 import socket
 import logging
+from importlib.metadata import PackageNotFoundError, version
 from urllib.parse import quote_plus
 from typing import Optional, List, Dict, Any
 
 # Timeout in seconds for crt.sh HTTP requests
 CRTSH_TIMEOUT = 15
+
+# User-Agent header sent with every crt.sh request. Reflects the installed
+# package version so server logs can correlate traffic to specific releases.
+try:
+    _pkg_version: str = version("check-tls")
+except PackageNotFoundError:  # pragma: no cover
+    _pkg_version = "unknown"
+
+USER_AGENT = f"check-tls/{_pkg_version}"
+
+# Delay between successive crt.sh requests in query_crtsh_multi.
+# Deliberate rate-limit to avoid hammering crt.sh. Override via the
+# CHECK_TLS_CRTSH_DELAY environment variable (seconds, float).
+try:
+    CRTSH_RATE_LIMIT_DELAY_SEC = max(0.0, float(os.getenv("CHECK_TLS_CRTSH_DELAY", "0.5")))
+except (TypeError, ValueError):
+    CRTSH_RATE_LIMIT_DELAY_SEC = 0.5
 
 
 def get_parent_domains(domain: str) -> list:
@@ -55,7 +74,7 @@ def query_crtsh(domain: str) -> Optional[List[Dict[str, Any]]]:
     logging.info(f"Querying crt.sh for {domain}")
     try:
         req = urllib.request.Request(
-            url, headers={'User-Agent': 'Python-CertCheck/1.3'}
+            url, headers={'User-Agent': USER_AGENT}
         )
         with urllib.request.urlopen(req, timeout=CRTSH_TIMEOUT) as response:
             if response.status == 200:
@@ -110,5 +129,5 @@ def query_crtsh_multi(domain: str) -> dict:
     for d in get_parent_domains(domain):
         res = query_crtsh(d)
         results[d] = res
-        sleep(0.5)  # avoid hammering crt.sh
+        sleep(CRTSH_RATE_LIMIT_DELAY_SEC)
     return results

--- a/tests/test_crtsh_utils.py
+++ b/tests/test_crtsh_utils.py
@@ -1,0 +1,69 @@
+"""
+test_crtsh_utils.py
+
+Unit tests for crtsh_utils module-level constants: USER_AGENT and
+CRTSH_RATE_LIMIT_DELAY_SEC (including env-var override behavior).
+"""
+
+import importlib
+import check_tls.utils.crtsh_utils as crtsh_utils
+
+
+class TestUserAgent:
+    """Tests for the USER_AGENT constant."""
+
+    def test_user_agent_is_non_empty(self):
+        """USER_AGENT must be a non-empty string."""
+        assert isinstance(crtsh_utils.USER_AGENT, str)
+        assert len(crtsh_utils.USER_AGENT) > 0
+
+    def test_user_agent_starts_with_package_prefix(self):
+        """USER_AGENT must start with 'check-tls/' to identify the package."""
+        assert crtsh_utils.USER_AGENT.startswith("check-tls/")
+
+    def test_user_agent_contains_version(self):
+        """USER_AGENT must include a version component after the slash."""
+        prefix = "check-tls/"
+        assert crtsh_utils.USER_AGENT.startswith(prefix)
+        version_part = crtsh_utils.USER_AGENT[len(prefix):]
+        assert len(version_part) > 0
+
+
+class TestRateLimitDelay:
+    """Tests for the CRTSH_RATE_LIMIT_DELAY_SEC constant and env-var override."""
+
+    def test_default_delay(self):
+        """Default rate-limit delay is 0.5 seconds when env var is not set."""
+        # This assumes CHECK_TLS_CRTSH_DELAY is not set in the test environment.
+        # The module was loaded without the env var, so it should be 0.5.
+        assert crtsh_utils.CRTSH_RATE_LIMIT_DELAY_SEC == 0.5
+
+    def test_env_var_override(self, monkeypatch):
+        """CHECK_TLS_CRTSH_DELAY env var sets the rate-limit delay on module reload."""
+        monkeypatch.setenv("CHECK_TLS_CRTSH_DELAY", "1.5")
+        importlib.reload(crtsh_utils)
+        try:
+            assert crtsh_utils.CRTSH_RATE_LIMIT_DELAY_SEC == 1.5
+        finally:
+            monkeypatch.delenv("CHECK_TLS_CRTSH_DELAY", raising=False)
+            importlib.reload(crtsh_utils)
+
+    def test_invalid_env_var_falls_back_to_default(self, monkeypatch):
+        """An invalid CHECK_TLS_CRTSH_DELAY value falls back to 0.5 seconds."""
+        monkeypatch.setenv("CHECK_TLS_CRTSH_DELAY", "not-a-float")
+        importlib.reload(crtsh_utils)
+        try:
+            assert crtsh_utils.CRTSH_RATE_LIMIT_DELAY_SEC == 0.5
+        finally:
+            monkeypatch.delenv("CHECK_TLS_CRTSH_DELAY", raising=False)
+            importlib.reload(crtsh_utils)
+
+    def test_negative_env_var_clamped_to_zero(self, monkeypatch):
+        """A negative CHECK_TLS_CRTSH_DELAY value is clamped to 0.0."""
+        monkeypatch.setenv("CHECK_TLS_CRTSH_DELAY", "-1.0")
+        importlib.reload(crtsh_utils)
+        try:
+            assert crtsh_utils.CRTSH_RATE_LIMIT_DELAY_SEC == 0.0
+        finally:
+            monkeypatch.delenv("CHECK_TLS_CRTSH_DELAY", raising=False)
+            importlib.reload(crtsh_utils)


### PR DESCRIPTION
## Summary

- **User-Agent**: replaced the hardcoded `Python-CertCheck/1.3` string with a dynamic `check-tls/<version>` value sourced at module load via `importlib.metadata.version("check-tls")`, falling back to `unknown` when the package is not installed. Uses the same pattern already in `check_tls/__init__.py`, with no circular-import risk (`crtsh_utils` is a leaf module).
- **Rate-limit delay**: extracted the hardcoded `sleep(0.5)` in `query_crtsh_multi` into a module-level constant `CRTSH_RATE_LIMIT_DELAY_SEC`. The constant defaults to `0.5` seconds but can be overridden at startup via the `CHECK_TLS_CRTSH_DELAY` environment variable (float, clamped to ≥ 0). Invalid values fall back silently to `0.5`.

## Commits

- `chore(crtsh): use package version in User-Agent header` — both `USER_AGENT` and `CRTSH_RATE_LIMIT_DELAY_SEC` live in the same file so they landed in one commit rather than two; splitting a single-file change would have been artificial.
- `test(crtsh): cover USER_AGENT and rate-limit env override` — 4 tests: non-empty UA starting with `check-tls/`, env-var override to `1.5`, invalid env-var fallback to `0.5`, negative value clamped to `0.0`.

## Test plan

- [ ] `ALLOW_INTERNAL_IPS=true uv run pytest tests/ -v` → 14 passed
- [ ] `uv run --with ruff ruff check src/ tests/` → no new errors introduced (23 pre-existing errors unchanged)
- [ ] Manually verify `USER_AGENT` reflects installed version: `python -c "from check_tls.utils.crtsh_utils import USER_AGENT; print(USER_AGENT)"`
- [ ] Verify env override: `CHECK_TLS_CRTSH_DELAY=2.0 python -c "from check_tls.utils.crtsh_utils import CRTSH_RATE_LIMIT_DELAY_SEC; print(CRTSH_RATE_LIMIT_DELAY_SEC)"`