### PR TITLE
fix(web): N/A badge for skipped CAA check (consistency with CRL/OCSP)

### DIFF
--- a/src/check_tls/static/js/app.js
+++ b/src/check_tls/static/js/app.js
@@ -84,7 +84,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   function caaBadge(caa) {
-    if (!caa || !caa.checked) return '<span class="badge bg-secondary">NOT DEFINED</span>';
+    if (!caa || !caa.checked) return '<span class="badge bg-secondary">N/A</span>';
     if (caa.error) return '<span class="badge badge-expired">KO</span>';
     if (caa.found) return '<span class="badge badge-ok">OK</span>';
     return '<span class="badge badge-warning">NOT DEFINED</span>';


### PR DESCRIPTION
## Context

PR #25 made `caa_check.checked=False` properly propagate when `--no-caa-check` is set. Before #25, the field was always `True`, so the JS rendering never had to distinguish 'skipped' from 'no records found'.

After #25, the JS still rendered both as 'NOT DEFINED', losing the distinction.

## Fix

`caaBadge()` returns 'N/A' (gray) when `!caa.checked` — same convention as `crlBadge` and `ocspBadge`. 'NOT DEFINED' (yellow warning) is preserved for the genuine 'checked but no CAA records' case.

## Test plan

- [x] Manual: load index page with 'Disable CAA Check' ticked → badge shows 'N/A' instead of ambiguous 'NOT DEFINED'.
- No automated test — caaBadge isn't currently covered; the web JS test suite tests headers and tooltip escaping (added in #27).