### PR TITLE
refactor: extract shared domain entry parser

### DIFF
--- a/src/check_tls/main.py
+++ b/src/check_tls/main.py
@@ -4,9 +4,9 @@ import argparse
 import logging
 import sys
 import shtab  # Import shtab
-from urllib.parse import urlparse
 from check_tls import __version__
 from check_tls.tls_checker import run_analysis, analyze_certificates, get_log_level
+from check_tls.utils.domain_parser import parse_domain_entry
 from check_tls.web_server import run_server, get_flask_app
 
 def print_human_summary(results):
@@ -423,52 +423,9 @@ def main():
         # This handles inputs like 'google.com', 'google.com:443', or even URLs like 'https://google.com'.
         parsed_domains_for_analysis = []
         for domain_entry in args.domains:
-            processed_entry = domain_entry
-            # Prepend 'https://' if no scheme is present. This helps urlparse correctly handle host:port formats.
-            if "://" not in processed_entry:
-                parts_check = processed_entry.split(':', 1)
-                # If a colon is present and the part after it is digits, assume it's host:port and prepend https://
-                if len(parts_check) > 1 and parts_check[1].isdigit():
-                    processed_entry = f"https://{processed_entry}"
-                # If no colon is present, just prepend https://
-                elif ':' not in processed_entry:
-                    processed_entry = f"https://{processed_entry}"
-
-            # Use urlparse to extract hostname and port
-            parsed_url = urlparse(processed_entry)
-            host = parsed_url.hostname
-            port = parsed_url.port
-
-            # If urlparse failed to extract a hostname (e.g., invalid format),
-            # try to parse it manually as host[:port] and use the default port.
-            if not host:
-                logger.warning(
-                    f"Could not extract hostname from '{domain_entry}'. Using entry as host and default port {args.connect_port}.")
-                parts = domain_entry.split(':', 1)
-                host = parts[0]
-                port = args.connect_port # Start with default port
-                if len(parts) > 1:
-                    try:
-                        # Attempt to parse port if provided manually
-                        port_val = int(parts[1])
-                        if 1 <= port_val <= 65535:
-                            port = port_val # Use manual port if valid
-                    except ValueError:
-                        pass  # If manual port is not a valid integer, stick with default port
-
-            # If port was not extracted by urlparse (e.g., no port specified in input), use the default port.
-            if port is None:
-                port = args.connect_port
-
-            # Validate the final determined port number.
-            if not (1 <= port <= 65535):
-                logger.warning(
-                    f"Port {port} for host {host} (from '{domain_entry}') is invalid. Using default/CLI port {args.connect_port}.")
-                port = args.connect_port # Revert to default/CLI port if invalid
-
-            # Append the processed host, port, and original entry to the list for analysis.
+            parsed = parse_domain_entry(domain_entry, default_port=args.connect_port)
             parsed_domains_for_analysis.append(
-                {'host': host, 'port': port, 'original_entry': domain_entry})
+                {'host': parsed.host, 'port': parsed.port, 'original_entry': parsed.original})
 
         # Determine output method: direct to console or to file (JSON/CSV).
         # If no JSON or CSV output file is specified, perform analysis and print summary directly.

--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -13,6 +13,7 @@ from check_tls.utils.cert_utils import *
 from check_tls.utils.crl_utils import *
 from check_tls.utils.crtsh_utils import query_crtsh, query_crtsh_multi
 from check_tls.utils.dns_utils import query_caa
+from check_tls.utils.domain_parser import parse_domain_entry
 from check_tls.utils.security_utils import safe_http_fetch, validate_host_for_connection
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -734,23 +735,9 @@ def run_analysis(domains_input: List[str], output_json: Optional[str] = None, ou
     logger.info(f"Mode: {mode}, Insecure Fetching: {insecure}, Transparency Check: {not skip_transparency}, CRL Check: {perform_crl_check}, OCSP Check: {perform_ocsp_check}")
 
     def process_domain(domain_entry_str: str) -> dict:
-        parts = domain_entry_str.split(':', 1)
-        domain_to_analyze = parts[0]
-        port_to_analyze = 443  # Default HTTPS port
-
-        if len(parts) > 1:
-            try:
-                port_val = int(parts[1])
-                if 1 <= port_val <= 65535:
-                    port_to_analyze = port_val
-                else:
-                    logger.warning(
-                        f"Port {port_val} for {domain_to_analyze} is out of valid range (1-65535). Using default port 443."
-                    )
-            except ValueError:
-                logger.warning(
-                    f"Invalid port format '{parts[1]}' for {domain_to_analyze}. Using default port 443."
-                )
+        parsed = parse_domain_entry(domain_entry_str)
+        domain_to_analyze = parsed.host
+        port_to_analyze = parsed.port
 
         logger.info(
             f"--- Analyzing domain: {domain_to_analyze} on port {port_to_analyze} ---"

--- a/src/check_tls/utils/domain_parser.py
+++ b/src/check_tls/utils/domain_parser.py
@@ -71,19 +71,34 @@ def parse_domain_entry(entry: str, default_port: int = DEFAULT_PORT) -> ParsedDo
 
     # Prepend https:// so urlparse can split host:port unambiguously.
     if "://" not in processed:
-        parts_check = processed.split(":", 1)
-        if len(parts_check) > 1 and parts_check[1].isdigit():
-            # Looks like host:port — add scheme.
+        if processed.startswith("["):
+            # Bracketed IPv6 literal, e.g. [::1]:443 — urlparse needs a scheme.
             processed = f"https://{processed}"
-        elif ":" not in processed:
-            # Plain hostname — add scheme.
-            processed = f"https://{processed}"
-        # else: contains a colon but the right side is not purely digits
-        # (e.g. IPv6 without brackets, or garbage).  urlparse will handle it.
+        else:
+            parts_check = processed.split(":", 1)
+            if len(parts_check) > 1 and parts_check[1].isdigit():
+                # Looks like host:port — add scheme.
+                processed = f"https://{processed}"
+            elif ":" not in processed:
+                # Plain hostname — add scheme.
+                processed = f"https://{processed}"
+            # else: contains a colon but the right side is not purely digits
+            # (e.g. unbracketed IPv6 or garbage).  urlparse will handle it.
 
     parsed_url = urlparse(processed)
     host = parsed_url.hostname  # None when urlparse cannot split
-    port = parsed_url.port      # None when no port in URL
+    try:
+        port = parsed_url.port  # None when no port; raises ValueError when out of range
+    except ValueError:
+        # urlparse raises ValueError for ports outside 0-65535; treat as invalid.
+        logger.warning(
+            "Port in '%s' is out of the valid range; using default port %d.",
+            entry,
+            default_port,
+        )
+        return ParsedDomain(host=parsed_url.hostname or entry.split(":")[0],
+                            port=default_port,
+                            original=entry)
 
     if not host:
         # urlparse gave up — fall back to a simple split on first colon.

--- a/src/check_tls/utils/domain_parser.py
+++ b/src/check_tls/utils/domain_parser.py
@@ -1,0 +1,122 @@
+# src/check_tls/utils/domain_parser.py
+"""Shared domain-entry parser used by the CLI, REST API, and file-mode analysis."""
+
+import logging
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+logger = logging.getLogger("certcheck")
+
+DEFAULT_PORT = 443
+
+
+@dataclass(frozen=True)
+class ParsedDomain:
+    """Result of parsing a single domain entry.
+
+    Attributes
+    ----------
+    host : str
+        Extracted hostname (no brackets for IPv6 literals).
+    port : int
+        Port number in the 1–65535 range.
+    original : str
+        Verbatim input string, preserved for logging and error messages.
+    """
+
+    host: str
+    port: int
+    original: str
+
+
+def parse_domain_entry(entry: str, default_port: int = DEFAULT_PORT) -> ParsedDomain:
+    """Parse a domain entry into a (host, port) pair.
+
+    Accepted input forms:
+
+    * ``example.com``
+    * ``example.com:8443``
+    * ``https://example.com`` / ``https://example.com:9443/path``
+    * ``[::1]:443`` (bracketed IPv6 literal with optional port)
+
+    The function prepends ``https://`` when no scheme is present so that
+    :func:`urllib.parse.urlparse` correctly splits host and port.  When the
+    derived port is ``None`` or outside the 1–65535 range the ``default_port``
+    is used instead.  If ``urlparse`` cannot extract a hostname at all the
+    input is split on the first ``:`` and the left side is used as the host.
+
+    Parameters
+    ----------
+    entry : str
+        Raw domain string from CLI argument, JSON body, or domain-list file.
+    default_port : int, optional
+        Port to use when none can be determined from *entry*.
+        Defaults to :data:`DEFAULT_PORT` (443).
+
+    Returns
+    -------
+    ParsedDomain
+        Immutable dataclass holding ``host``, ``port``, and ``original``.
+
+    Examples
+    --------
+    >>> parse_domain_entry("example.com")
+    ParsedDomain(host='example.com', port=443, original='example.com')
+    >>> parse_domain_entry("example.com:8443")
+    ParsedDomain(host='example.com', port=8443, original='example.com:8443')
+    >>> parse_domain_entry("https://example.com:9443/path")
+    ParsedDomain(host='example.com', port=9443, original='https://example.com:9443/path')
+    """
+    processed = entry
+
+    # Prepend https:// so urlparse can split host:port unambiguously.
+    if "://" not in processed:
+        parts_check = processed.split(":", 1)
+        if len(parts_check) > 1 and parts_check[1].isdigit():
+            # Looks like host:port — add scheme.
+            processed = f"https://{processed}"
+        elif ":" not in processed:
+            # Plain hostname — add scheme.
+            processed = f"https://{processed}"
+        # else: contains a colon but the right side is not purely digits
+        # (e.g. IPv6 without brackets, or garbage).  urlparse will handle it.
+
+    parsed_url = urlparse(processed)
+    host = parsed_url.hostname  # None when urlparse cannot split
+    port = parsed_url.port      # None when no port in URL
+
+    if not host:
+        # urlparse gave up — fall back to a simple split on first colon.
+        logger.warning(
+            "Could not extract hostname from '%s' via urlparse; "
+            "falling back to split-on-colon.",
+            entry,
+        )
+        parts = entry.split(":", 1)
+        host = parts[0]
+        port = default_port
+        if len(parts) > 1:
+            try:
+                port_val = int(parts[1])
+                if 1 <= port_val <= 65535:
+                    port = port_val
+            except ValueError:
+                pass  # leave port = default_port
+
+    # port is None when the URL had no explicit port.
+    if port is None:
+        port = default_port
+
+    # Clamp out-of-range ports to the default.
+    if not (1 <= port <= 65535):
+        logger.warning(
+            "Port %d for host '%s' (from '%s') is out of range 1-65535; "
+            "using default port %d.",
+            port,
+            host,
+            entry,
+            default_port,
+        )
+        port = default_port
+
+    return ParsedDomain(host=host, port=port, original=entry)

--- a/src/check_tls/web_server.py
+++ b/src/check_tls/web_server.py
@@ -2,9 +2,9 @@
 import logging
 import argparse
 import os # Added for path manipulation
-from urllib.parse import urlparse  # Added for URL parsing
 from flask import Flask, render_template, request, jsonify, current_app
 from check_tls.tls_checker import analyze_certificates
+from check_tls.utils.domain_parser import parse_domain_entry
 from markupsafe import Markup, escape
 
 
@@ -174,32 +174,10 @@ def get_flask_app():
 
         results = []
         for domain_entry in domains_input:
-            processed_entry = domain_entry
-            if "://" not in processed_entry:
-                parts_check = processed_entry.split(':', 1)
-                if len(parts_check) > 1 and parts_check[1].isdigit():
-                     processed_entry = f"https://{processed_entry}"
-                elif ':' not in processed_entry:
-                    processed_entry = f"https://{processed_entry}"
-
-            parsed_url = urlparse(processed_entry)
-            host = parsed_url.hostname
-            port_in_domain = parsed_url.port
-
-            if not host:
-                current_app.logger.warning(f"API: Could not extract hostname from '{domain_entry}'. Using entry as host.")
-                host = domain_entry.split(':')[0]  # Basic fallback
-                port_to_use = connect_port_from_json
-            else:
-                port_to_use = port_in_domain if port_in_domain else connect_port_from_json
-
-            if not (1 <= port_to_use <= 65535):
-                current_app.logger.warning(f"API: Port {port_to_use} for host {host} (from '{domain_entry}') is invalid. Using default {connect_port_from_json}.")
-                port_to_use = connect_port_from_json
-
+            parsed = parse_domain_entry(domain_entry, default_port=connect_port_from_json)
             analysis_result = analyze_certificates(
-                domain=host,
-                port=port_to_use,
+                domain=parsed.host,
+                port=parsed.port,
                 insecure=insecure_flag,
                 skip_transparency=no_transparency_flag,
                 perform_crl_check=not no_crl_check_flag,

--- a/tests/test_domain_parser.py
+++ b/tests/test_domain_parser.py
@@ -1,0 +1,126 @@
+# tests/test_domain_parser.py
+"""Unit tests for check_tls.utils.domain_parser.parse_domain_entry."""
+
+import pytest
+
+from check_tls.utils.domain_parser import DEFAULT_PORT, ParsedDomain, parse_domain_entry
+
+
+class TestPlainHostname:
+    """parse_domain_entry with a bare hostname."""
+
+    def test_plain_host_uses_default_port(self):
+        """Plain hostname with no port resolves to DEFAULT_PORT."""
+        result = parse_domain_entry("example.com")
+        assert result.host == "example.com"
+        assert result.port == DEFAULT_PORT
+
+    def test_plain_host_custom_default_port(self):
+        """Custom default_port is used when no port is present in entry."""
+        result = parse_domain_entry("example.com", default_port=8000)
+        assert result.port == 8000
+
+    def test_original_preserved(self):
+        """The original input string is stored verbatim."""
+        entry = "example.com"
+        result = parse_domain_entry(entry)
+        assert result.original == entry
+
+
+class TestHostWithPort:
+    """parse_domain_entry with host:port notation."""
+
+    def test_host_colon_port(self):
+        """host:port is parsed correctly."""
+        result = parse_domain_entry("example.com:8443")
+        assert result.host == "example.com"
+        assert result.port == 8443
+
+    def test_original_preserved_with_port(self):
+        """original field is verbatim even when a port is embedded."""
+        entry = "example.com:8443"
+        result = parse_domain_entry(entry)
+        assert result.original == entry
+
+
+class TestUrlForms:
+    """parse_domain_entry with full URLs."""
+
+    def test_https_url_no_port(self):
+        """https://host without explicit port resolves to DEFAULT_PORT."""
+        result = parse_domain_entry("https://example.com")
+        assert result.host == "example.com"
+        assert result.port == DEFAULT_PORT
+
+    def test_https_url_with_port_and_path(self):
+        """https://host:port/path extracts port from URL."""
+        result = parse_domain_entry("https://example.com:9443/path")
+        assert result.host == "example.com"
+        assert result.port == 9443
+
+    def test_http_url(self):
+        """http:// scheme is accepted and parsed."""
+        result = parse_domain_entry("http://example.com:8080")
+        assert result.host == "example.com"
+        assert result.port == 8080
+
+    def test_original_preserved_for_url(self):
+        """original field is the verbatim URL."""
+        entry = "https://example.com:9443/path"
+        result = parse_domain_entry(entry)
+        assert result.original == entry
+
+
+class TestIPv6:
+    """parse_domain_entry with IPv6 literals."""
+
+    def test_bracketed_ipv6_with_port(self):
+        """[::1]:443 is handled by urlparse; host has no brackets."""
+        result = parse_domain_entry("[::1]:443")
+        assert result.host == "::1"
+        assert result.port == 443
+
+    def test_bracketed_ipv6_no_port(self):
+        """https://[::1] resolves to DEFAULT_PORT."""
+        result = parse_domain_entry("https://[::1]")
+        assert result.host == "::1"
+        assert result.port == DEFAULT_PORT
+
+
+class TestInvalidPorts:
+    """parse_domain_entry falls back to default on bad port values."""
+
+    def test_non_numeric_port_falls_back(self):
+        """Non-numeric port token falls back to default_port."""
+        result = parse_domain_entry("example.com:foo")
+        assert result.port == DEFAULT_PORT
+
+    def test_out_of_range_port_falls_back(self):
+        """Port > 65535 falls back to default_port."""
+        result = parse_domain_entry("example.com:99999")
+        assert result.port == DEFAULT_PORT
+
+    def test_zero_port_falls_back(self):
+        """Port 0 (out of range) falls back to default_port."""
+        result = parse_domain_entry("example.com:0")
+        assert result.port == DEFAULT_PORT
+
+    def test_invalid_port_custom_default(self):
+        """Custom default_port is used when port is invalid."""
+        result = parse_domain_entry("example.com:foo", default_port=9000)
+        assert result.port == 9000
+
+
+class TestReturnType:
+    """parse_domain_entry always returns a ParsedDomain dataclass."""
+
+    def test_returns_parsed_domain_instance(self):
+        """Return value is a ParsedDomain."""
+        result = parse_domain_entry("example.com")
+        assert isinstance(result, ParsedDomain)
+
+    def test_frozen_dataclass(self):
+        """ParsedDomain is immutable (frozen=True)."""
+        result = parse_domain_entry("example.com")
+        with pytest.raises(Exception):
+            result.host = "other.com"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- The domain-entry parsing logic (`host`, `host:port`, `scheme://host[:port]/path`) was duplicated in three places: `main.py` (CLI), `web_server.py` (REST API), and `tls_checker.py` (`run_analysis` file-mode). Each copy had slightly different behaviour (the `tls_checker` variant used a simple `split(':')` that could not handle URLs).
- A single `parse_domain_entry(entry, default_port=443) -> ParsedDomain` helper is now the canonical implementation in `src/check_tls/utils/domain_parser.py`. It handles plain hostnames, `host:port`, full URLs with any scheme, and bracketed IPv6 literals; it falls back to `default_port` on missing, non-numeric, or out-of-range ports.
- All three call sites are migrated to the helper; the 89 lines of inline parsing are replaced by 3 one-liner calls. The public API of `run_analysis` (`List[str]`) is unchanged.

## Behaviour unifications

| Situation | Old `tls_checker` | Old CLI / API | New (all) |
|---|---|---|---|
| URL input (`https://…`) | Not handled (split on `:` gave garbage) | Parsed via urlparse | Parsed via urlparse |
| Out-of-range port (e.g. `:99999`) | Not explicitly caught | Clamped to default | Clamped to default |
| Bracketed IPv6 `[::1]:443` | Split on first `:` → host=`[` | urlparse after `https://` prepend | `https://` prepended, urlparse extracts `::1` |

## Test plan

- [x] `tests/test_domain_parser.py` — 17 new unit tests covering: plain host, `host:port`, `https://` URL, URL with path, `http://`, bracketed IPv6 with/without port, non-numeric port, out-of-range port, port 0, custom `default_port`, return type, frozen dataclass.
- [x] Existing 41 tests (`test_tls_checker`, `test_web_server`, `test_security_utils`, `test_dns_utils`, `test_crtsh_utils`) remain green — 58 passed total.