### PR TITLE
feat(web): production-grade Waitress server with dev escape hatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common commands
+
+Project uses `uv` for environments and `pytest`/`ruff` for tests/lint (see project memory).
+
+```sh
+# Editable install for development
+uv pip install -e .
+
+# Run from source (no install required if PYTHONPATH=src)
+python -m check_tls.main example.com
+python -m check_tls.main --server -p 8000   # web UI on http://*:8000 (IPv4 + IPv6 via Waitress)
+CHECK_TLS_DEV=1 python -m check_tls.main --server -p 8000  # dev mode: Werkzeug with live reload (NOT for prod)
+
+# Tests
+pytest                                       # full suite
+pytest tests/test_tls_checker.py -k mismatch # single test by name pattern
+
+# Lint
+ruff check .
+
+# Build wheel/sdist (versioned via setuptools_scm from git tags)
+python -m build
+SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 python -m build   # when not on a tagged commit
+
+# Docker (multi-stage, Alpine + Rust for cryptography)
+docker build --build-arg APP_VERSION=0.0.0 -t check-tls .
+docker run --rm check-tls example.com
+docker run --rm -p 8000:8000 check-tls --server
+```
+
+The console script `check-tls` (defined in `pyproject.toml`) is identical to `python -m check_tls.main`.
+
+## Architecture
+
+Single Python package `check_tls` exposing both a CLI and a Flask web UI/REST API over the same analysis core. `src/` layout; `setuptools_scm` derives `__version__` from git tags at install time (falls back to `0.0.0` when the package metadata is missing).
+
+Three layers:
+
+1. **Entry points** — `check_tls.main` (CLI / argparse + shtab completion) and `check_tls.web_server` (Flask app factory `get_flask_app()` + `run_server()`). Both parse a domain spec into `(host, port)` using the same logic: schemes are added when missing, then `urllib.parse.urlparse` extracts host/port, with a manual `host:port` fallback. Any change to that parsing must be applied in **both** places (`main.py` and `web_server.py::api_analyze`) to keep CLI and API behavior in sync.
+
+2. **Analysis core** — `check_tls.tls_checker`. The two public entry points are:
+   - `analyze_certificates(domain, port, mode, insecure, skip_transparency, perform_crl_check, perform_ocsp_check, perform_caa_check)` → returns the per-domain result dict (keys: `domain`, `status`, `connection_health`, `validation`, `certificates`, `crl_check`, `transparency`, `ocsp_check`, `caa_check`, optional `error_message`). This is the canonical result shape used by JSON output, CSV output, the HTML template, and the REST API. Any new field must be added consistently across all four consumers.
+   - `run_analysis(...)` — multi-domain wrapper that handles JSON/CSV file output (`-` means stdout).
+   - `fetch_leaf_certificate_and_conn_info()` deliberately disables `check_hostname` on the SSL context so the leaf certificate is always retrievable; hostname verification is then performed manually using `ssl._dnsname_match` so mismatches surface in `connection_health.error` with full `not_valid_before` / `not_valid_after` context (the regression tests in `tests/test_tls_checker.py` assert this exact behavior — don't switch back to automatic hostname checking).
+
+3. **Utilities** — `check_tls.utils` provides single-purpose modules: `cert_utils` (x509 parsing, SAN/CN extraction, profile detection from KeyUsage/EKU), `crl_utils` (CRL fetch + revocation check), `crtsh_utils` (Certificate Transparency via crt.sh), `dns_utils` (CAA records via `dnspython`), `ocsp_utils` (OCSP responder check). `tls_checker.py` does `from check_tls.utils.cert_utils import *` — when adding helpers there, mind the wildcard surface.
+
+Web UI assets live in `src/check_tls/templates/` and `src/check_tls/static/` and are packaged via `[tool.setuptools.package-data]`. The Flask app resolves them via paths relative to `web_server.py`, not via `package_data` lookups, so renaming those folders requires updating `get_flask_app()`.
+
+The web server binds to `*` (Waitress wildcard — dual-stack IPv4+IPv6 on all interfaces) — keep it that way; it's a documented feature.  Setting `CHECK_TLS_DEV=1` falls back to Flask's Werkzeug dev server with `debug=True`; never use that in production.
+
+## Testing notes
+
+Tests in `tests/test_tls_checker.py` spin up an in-process TLS server on `127.0.0.1` with a self-signed or CA-signed cert (built via `cryptography`) to exercise hostname-mismatch and expired-cert error reporting end-to-end. The expired-cert test monkeypatches `ssl.create_default_context` to inject a custom CA — preserve that pattern instead of mocking `analyze_certificates` internals. Tests assert exact substrings in error messages (`"Hostname mismatch"`, `"SSL certificate verification failed"`, `not_valid_before_utc.isoformat()`); error-message wording is part of the contract.
+
+## Release flow
+
+Two GitHub Actions workflows in `.github/workflows/`:
+
+- `publish-to-pypi.yaml` — runs on GitHub release publish; builds with `python -m build` and `twine upload`s. The release tag must match the version `setuptools_scm` will derive.
+- `build-and-publish.yaml` — Docker multi-arch build (`linux/amd64,arm64,i386`), pushes to `ghcr.io/obeone/check-tls` and `docker.io/obeoneorg/check-tls`, signs with cosign. Tag-named images are produced only on `release` events; `main` pushes update `:latest` only.
+
+`APP_VERSION` is plumbed into the Dockerfile via `--build-arg` so the wheel built inside the image carries the right version (`SETUPTOOLS_SCM_PRETEND_VERSION`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "shtab>=1.7.1,<2.0.0",
     "requests>=2.31.0,<3.0.0",
     "dnspython>=2.4.2,<3.0.0",
+    "waitress>=3.0.0,<4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/check_tls/web_server.py
+++ b/src/check_tls/web_server.py
@@ -215,28 +215,38 @@ def get_flask_app():
 
 
 def run_server(args):
+    """Run the Flask app behind Waitress on the given port (dual-stack IPv6 by default).
+
+    For development/debug, set ``CHECK_TLS_DEV=1`` to fall back to Flask's
+    built-in Werkzeug server with ``debug=True`` — convenient for live reload
+    but **not** suitable for production use.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed command-line arguments.  Must contain at minimum:
+
+        * ``port`` (int) — TCP port to listen on.
+
+    Notes
+    -----
+    The production path uses ``waitress.serve`` with ``listen="*:PORT"``
+    (Waitress wildcard) which binds to both IPv4 and IPv6 interfaces.
+    ``threads=8`` provides basic concurrency without requiring an async
+    runtime.  The ``ident`` parameter suppresses Waitress's default
+    ``Server`` header so the implementation detail is not advertised.
     """
-    Run the Flask web server for interactive TLS analysis.
+    logger = logging.getLogger(__name__)
+    app = get_flask_app()
 
-    This function initializes the Flask application, sets up routes for the
-    web interface and API, and starts the server on the specified port.
+    if os.getenv("CHECK_TLS_DEV", "").lower() in {"1", "true", "yes"}:
+        logger.warning(
+            "CHECK_TLS_DEV is set — running Werkzeug dev server (NOT for production)."
+        )
+        app.run(host="::", port=args.port, debug=True)
+        return
 
-    Args:
-        args (argparse.Namespace): Parsed command-line arguments containing
-            configuration options such as the port number and flags for
-            insecure connections, transparency checks, and CRL checks.
+    from waitress import serve  # noqa: PLC0415 – intentional lazy import
 
-    Routes:
-        '/' (GET): Main page for domain input and displaying results.
-        '/api/analyze' (POST): API endpoint for JSON-based domain analysis.
-
-    The web interface supports form submission with domain names and options,
-    and returns analysis results rendered in HTML or JSON format based on the
-    Accept header.
-    """
-    logging.info(f"Starting Flask server on http://[::]:{args.port}")
-    try:
-        app = get_flask_app()
-        app.run(host='::', port=args.port, debug=False)
-    except Exception as e:
-        logging.error(f"Failed to start Flask server: {e}")
+    logger.info("Starting Waitress on http://*:%d (IPv4 + IPv6)", args.port)
+    serve(app, listen=f"*:{args.port}", threads=8, ident="check-tls")

--- a/tests/test_run_server.py
+++ b/tests/test_run_server.py
@@ -1,0 +1,128 @@
+"""Tests for run_server dev/prod branching in web_server.py."""
+import argparse
+import importlib
+
+import pytest
+
+
+def _args(port=18000):
+    """Return a minimal argparse.Namespace suitable for run_server."""
+    return argparse.Namespace(port=port)
+
+
+# ---------------------------------------------------------------------------
+# Dev mode: CHECK_TLS_DEV=1  →  Flask built-in server
+# ---------------------------------------------------------------------------
+
+class TestRunServerDevMode:
+    """When CHECK_TLS_DEV is set, run_server delegates to Flask app.run."""
+
+    def test_calls_app_run_with_correct_args(self, monkeypatch):
+        """app.run must receive host='::', port, and debug=True."""
+        calls = {}
+
+        def fake_run(self, host, port, debug):  # noqa: D401
+            calls["host"] = host
+            calls["port"] = port
+            calls["debug"] = debug
+
+        import flask
+        monkeypatch.setenv("CHECK_TLS_DEV", "1")
+        monkeypatch.setattr(flask.Flask, "run", fake_run)
+
+        from check_tls.web_server import run_server
+        run_server(_args(port=18001))
+
+        assert calls["host"] == "::"
+        assert calls["port"] == 18001
+        assert calls["debug"] is True
+
+    def test_accepts_true_value(self, monkeypatch):
+        """CHECK_TLS_DEV=true (string) must also trigger dev mode."""
+        calls = {}
+
+        def fake_run(self, host, port, debug):
+            calls["invoked"] = True
+
+        import flask
+        monkeypatch.setenv("CHECK_TLS_DEV", "true")
+        monkeypatch.setattr(flask.Flask, "run", fake_run)
+
+        from check_tls.web_server import run_server
+        run_server(_args())
+
+        assert calls.get("invoked") is True
+
+    def test_does_not_call_waitress(self, monkeypatch):
+        """When CHECK_TLS_DEV is set, waitress.serve must NOT be called."""
+        import flask
+        monkeypatch.setenv("CHECK_TLS_DEV", "1")
+        monkeypatch.setattr(flask.Flask, "run", lambda *a, **kw: None)
+
+        import waitress as _waitress
+        waitress_calls = []
+        monkeypatch.setattr(_waitress, "serve", lambda *a, **kw: waitress_calls.append((a, kw)))
+
+        from check_tls.web_server import run_server
+        run_server(_args())
+
+        assert waitress_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Production mode: no CHECK_TLS_DEV  →  waitress.serve
+# ---------------------------------------------------------------------------
+
+class TestRunServerProdMode:
+    """Without CHECK_TLS_DEV, run_server must delegate to waitress.serve."""
+
+    def test_calls_waitress_serve(self, monkeypatch):
+        """waitress.serve must be called with the Flask app, listen, threads, ident."""
+        monkeypatch.delenv("CHECK_TLS_DEV", raising=False)
+
+        import waitress as _waitress
+        calls = {}
+
+        def fake_serve(app, listen, threads, ident):
+            calls["app"] = app
+            calls["listen"] = listen
+            calls["threads"] = threads
+            calls["ident"] = ident
+
+        monkeypatch.setattr(_waitress, "serve", fake_serve)
+
+        from check_tls.web_server import run_server
+        run_server(_args(port=18002))
+
+        assert calls["listen"] == "*:18002"
+        assert calls["threads"] == 8
+        assert calls["ident"] == "check-tls"
+
+    def test_does_not_call_app_run(self, monkeypatch):
+        """Flask's built-in server must NOT be called in production mode."""
+        monkeypatch.delenv("CHECK_TLS_DEV", raising=False)
+
+        import flask
+        import waitress as _waitress
+        flask_calls = []
+        monkeypatch.setattr(flask.Flask, "run", lambda *a, **kw: flask_calls.append((a, kw)))
+        monkeypatch.setattr(_waitress, "serve", lambda *a, **kw: None)
+
+        from check_tls.web_server import run_server
+        run_server(_args())
+
+        assert flask_calls == []
+
+    def test_app_passed_to_serve_is_flask_instance(self, monkeypatch):
+        """The object passed to waitress.serve must be a Flask application."""
+        import flask
+        import waitress as _waitress
+        monkeypatch.delenv("CHECK_TLS_DEV", raising=False)
+
+        received = {}
+        monkeypatch.setattr(_waitress, "serve", lambda app, listen, **kw: received.update(app=app))
+
+        from check_tls.web_server import run_server
+        run_server(_args())
+
+        assert isinstance(received["app"], flask.Flask)


### PR DESCRIPTION
## Summary

- Replaces Flask's Werkzeug development server with **Waitress 3.x** (`waitress>=3.0.0,<4.0.0`) — a production-quality pure-Python WSGI server with no native dependencies
- Binds via `listen="*:PORT"` (Waitress wildcard) which accepts both IPv4 and IPv6 connections on all interfaces, verified locally with `curl http://127.0.0.1:18000/` (200) and `curl http://[::1]:18000/` (200)
- Adds `CHECK_TLS_DEV=1` escape hatch: setting this env var reverts to Werkzeug with `debug=True` for local development with live reload

## What changed

| File | Change |
|------|--------|
| `pyproject.toml` | Added `waitress>=3.0.0,<4.0.0` runtime dependency |
| `src/check_tls/web_server.py` | Rewrote `run_server()` — Waitress in prod, Werkzeug when `CHECK_TLS_DEV=1` |
| `tests/test_run_server.py` | New: 6 tests covering dev/prod branching (monkeypatched, no real socket) |
| `CLAUDE.md` | Added project guidance + documented `CHECK_TLS_DEV` dev override |

## Dual-stack verification

```
$ uv run check-tls --server -p 18000 &
$ curl --max-time 3 -s -o /dev/null -w "%{http_code}" http://127.0.0.1:18000/
200
$ curl --max-time 3 -s -o /dev/null -w "%{http_code}" http://[::1]:18000/
200
```

## Test plan

- [x] `ALLOW_INTERNAL_IPS=true uv run pytest tests/ -v` → 47 passed, 0 failed
- [x] Manual QA: `uv run check-tls --server -p 18000` → IPv4 200, IPv6 200
- [x] Dockerfile unchanged — `ENTRYPOINT ["check-tls"]` + `--server` flag still routes through `run_server()`; HEALTHCHECK (`wget … http://localhost:8000/`) works identically behind Waitress