### PR TITLE
fix(security): is_ip_blocked fail-closed + DNS rebinding mitigation

### DIFF
--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -60,10 +60,17 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
         logger.warning("Could not set minimum TLS version on context (might be older Python/SSL version).")
 
     # Security validation: Check if the host resolves to private/internal IPs
-    # This prevents SSRF attacks by blocking connections to internal networks
-    # Set ALLOW_INTERNAL_IPS=true environment variable to disable this protection
+    # This prevents SSRF attacks by blocking connections to internal networks.
+    # Set ALLOW_INTERNAL_IPS=true environment variable to disable this protection.
+    # ``validate_host_for_connection`` also returns the IP it validated so we
+    # can pin ``socket.create_connection`` to that exact address — closing
+    # the DNS rebinding TOCTOU window between the validator's getaddrinfo
+    # and the socket layer's own getaddrinfo. SNI / hostname matching keeps
+    # using ``domain`` so cert validation is unaffected.
     allow_private = os.getenv('ALLOW_INTERNAL_IPS', 'false').lower() == 'true'
-    is_valid, validation_error = validate_host_for_connection(domain, port, allow_private_ips=allow_private)
+    is_valid, validation_error, resolved_ip = validate_host_for_connection(
+        domain, port, allow_private_ips=allow_private
+    )
 
     if not is_valid:
         logger.error(f"Security validation failed for {domain}:{port}: {validation_error}")
@@ -74,9 +81,14 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
     ssock = None
 
     try:
-        # Establish TCP connection to domain on specified port with timeout
-        sock = socket.create_connection((domain, port), timeout=10)
-        # Wrap socket with SSL context for TLS handshake
+        # Establish TCP connection — pin to the validated IP when one is
+        # available so DNS rebinding cannot redirect the socket between
+        # validation and connect().
+        connect_target = (resolved_ip or domain, port)
+        sock = socket.create_connection(connect_target, timeout=10)
+        # Wrap socket with SSL context for TLS handshake; ``server_hostname``
+        # stays the original domain so SNI and hostname matching work even
+        # when the socket is connected to a pinned IP.
         ssock = context.wrap_socket(sock, server_hostname=domain)
 
         # Extract TLS version and cipher suite details

--- a/src/check_tls/utils/security_utils.py
+++ b/src/check_tls/utils/security_utils.py
@@ -85,77 +85,119 @@ def is_ip_blocked(ip_address_str: str) -> Tuple[bool, Optional[str]]:
     return False, None
 
 
-def validate_host_for_connection(host: str, port: int, allow_private_ips: bool = False) -> Tuple[bool, Optional[str]]:
+def validate_host_for_connection(
+    host: str,
+    port: int,
+    allow_private_ips: bool = False,
+) -> Tuple[bool, Optional[str], Optional[str]]:
     """
     Validate a host before making a connection to prevent SSRF attacks.
 
-    This function checks if the host (domain or IP) resolves to a private/internal
-    IP address that could be exploited for SSRF attacks.
+    The function checks whether ``host`` (a domain name or an IP literal)
+    resolves to a private/internal IP address that could be abused for
+    SSRF. When ``host`` is a domain name and the validation succeeds, the
+    resolved IP that was actually validated is returned to the caller so
+    the connection can be **pinned** to that exact address — closing the
+    classic DNS-rebinding TOCTOU window where the validator and the
+    socket layer each perform their own DNS lookup with potentially
+    different answers.
 
-    Args:
-        host (str): The hostname or IP address to validate.
-        port (int): The port number (for logging purposes).
-        allow_private_ips (bool): If True, allow connections to private IPs.
-                                  Defaults to False for security.
+    Parameters
+    ----------
+    host : str
+        The hostname or IP address to validate.
+    port : int
+        The port number, used purely for logging context.
+    allow_private_ips : bool, optional
+        When ``True``, skip the SSRF allowlist entirely. The caller will
+        also resolve DNS naturally, so no pinned IP is returned in that
+        case. Defaults to ``False``.
 
-    Returns:
-        Tuple[bool, Optional[str]]:
-            - True if validation passed (host is safe to connect to)
-            - Error message if validation failed, None otherwise
+    Returns
+    -------
+    Tuple[bool, Optional[str], Optional[str]]
+        A 3-tuple ``(is_valid, error_message, resolved_ip)``:
 
-    Example:
-        >>> validate_host_for_connection('example.com', 443)
-        (True, None)
-        >>> validate_host_for_connection('192.168.1.1', 443)
-        (False, 'Blocked connection to private IP...')
+        * ``is_valid`` — ``True`` when the host is safe to connect to.
+        * ``error_message`` — non-``None`` only when ``is_valid`` is
+          ``False``.
+        * ``resolved_ip`` — the IP literal the caller should pin its
+          connection to. It is ``None`` when there is no rebind window
+          to close: ``host`` was already an IP literal, ``allow_private_ips``
+          was ``True``, DNS resolution failed (caller must surface a
+          fresh ``socket.gaierror`` itself), or validation failed.
+
+    Examples
+    --------
+    >>> validate_host_for_connection('example.com', 443)  # doctest: +SKIP
+    (True, None, '93.184.216.34')
+    >>> validate_host_for_connection('192.168.1.1', 443)
+    (False, 'Blocked connection to private/internal IP: ...', None)
     """
     logger = logging.getLogger("certcheck")
 
-    # If private IPs are explicitly allowed, skip validation
+    # If private IPs are explicitly allowed, skip validation entirely.
+    # No pinned IP is returned: the caller resolves DNS naturally.
     if allow_private_ips:
         logger.debug(f"Allowing connection to {host}:{port} (private IPs allowed)")
-        return True, None
+        return True, None, None
 
-    # Check if host is already an IP address
+    # Check if host is already an IP address. No DNS lookup means no
+    # rebind window to close, so resolved_ip stays None.
     try:
         ip = ipaddress.ip_address(host)
+    except ValueError:
+        ip = None
+
+    if ip is not None:
         is_blocked, block_msg = is_ip_blocked(str(ip))
         if is_blocked:
             error_msg = f"Blocked connection to private/internal IP: {block_msg}"
             logger.warning(error_msg)
-            return False, error_msg
-        # IP is public, allow connection
-        return True, None
-    except ValueError:
-        # Not an IP address, it's a hostname - need to resolve it
-        pass
+            return False, error_msg, None
+        return True, None, None
 
-    # Resolve hostname to IP address(es) and check each one
+    # Resolve hostname to IP address(es) and check each one. If ANY
+    # resolved IP is private/internal, block the whole connection —
+    # this preserves the previous behavior and avoids attacker-friendly
+    # round-robin DNS that mixes a public IP with a private one.
     try:
         resolved_ips = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM)
-        for result in resolved_ips:
-            family, socktype, proto, canonname, sockaddr = result
-            ip_str = sockaddr[0]  # Extract IP address
-
-            is_blocked, block_msg = is_ip_blocked(ip_str)
-            if is_blocked:
-                error_msg = f"Blocked connection to {host}:{port} - resolves to private/internal IP: {block_msg}"
-                logger.warning(error_msg)
-                return False, error_msg
-
-        # All resolved IPs are public, allow connection
-        logger.debug(f"Validated {host}:{port} - resolves to public IPs only")
-        return True, None
-
     except socket.gaierror as e:
-        # DNS resolution failed - let the connection attempt handle this error
+        # DNS resolution failed — let the caller surface its own error
+        # naturally on the actual connection attempt.
         logger.debug(f"DNS resolution failed for {host}: {e}")
-        return True, None  # Allow the connection to proceed and fail naturally with proper error
+        return True, None, None
     except Exception as e:
-        # Unexpected error during validation - fail closed for security
+        # Unexpected error during validation — fail closed for security.
         error_msg = f"Unexpected error validating host {host}: {e}"
         logger.error(error_msg)
-        return False, error_msg
+        return False, error_msg, None
+
+    first_validated_ip: Optional[str] = None
+    for family, socktype, proto, canonname, sockaddr in resolved_ips:
+        ip_str = sockaddr[0]  # Extract IP address
+
+        is_blocked, block_msg = is_ip_blocked(ip_str)
+        if is_blocked:
+            error_msg = (
+                f"Blocked connection to {host}:{port} - resolves to "
+                f"private/internal IP: {block_msg}"
+            )
+            logger.warning(error_msg)
+            return False, error_msg, None
+
+        if first_validated_ip is None:
+            first_validated_ip = ip_str
+
+    # All resolved IPs are public; pin the caller's socket to the first
+    # one we validated to defeat DNS rebinding between this lookup and
+    # the connect() that follows.
+    logger.debug(
+        f"Validated {host}:{port} - resolves to public IPs only "
+        f"(pinned to {first_validated_ip})"
+    )
+    return True, None, first_validated_ip
 
 
 def is_port_allowed(port: int, allowed_ports: Optional[set] = None) -> Tuple[bool, Optional[str]]:
@@ -314,7 +356,21 @@ def safe_http_fetch(
             logger.warning("safe_http_fetch: URL '%s' has an invalid port", current_url)
             return None
 
-        is_valid, validation_error = validate_host_for_connection(
+        # NOTE on DNS rebinding: ``validate_host_for_connection`` returns
+        # the IP it validated, but :mod:`requests` will perform its own
+        # DNS lookup when issuing the request, leaving a small race
+        # window. This is an accepted trade-off here:
+        #   * ``safe_http_fetch`` is only used to retrieve immutable,
+        #     application-layer-signed artefacts (CRLs, OCSP responses,
+        #     intermediate certificates), so a rebind to a private IP
+        #     would still need to serve a payload that is independently
+        #     verified by the caller; and
+        #   * pinning ``requests`` to an IP via URL rewriting would
+        #     break HTTPS hostname validation against the certificate.
+        # The TLS connection in ``tls_checker.fetch_leaf_certificate_and_conn_info``
+        # *does* pin the resolved IP because SNI keeps the hostname for
+        # cert validation independent of the socket address.
+        is_valid, validation_error, _resolved_ip = validate_host_for_connection(
             host, port, allow_private_ips=allow_private
         )
         if not is_valid:

--- a/src/check_tls/utils/security_utils.py
+++ b/src/check_tls/utils/security_utils.py
@@ -46,29 +46,43 @@ def is_ip_blocked(ip_address_str: str) -> Tuple[bool, Optional[str]]:
     """
     Check if an IP address is in a blocked range (private/internal networks).
 
-    Args:
-        ip_address_str (str): The IP address to check as a string.
+    The function fails closed: when ``ip_address_str`` cannot be parsed as
+    a valid IP literal, it is treated as blocked rather than allowed.
+    This prevents callers from accidentally bypassing the SSRF allowlist
+    with malformed input that earlier validation may have missed.
 
-    Returns:
-        Tuple[bool, Optional[str]]:
-            - True if the IP is blocked, False otherwise
-            - Error message if blocked, None otherwise
+    Parameters
+    ----------
+    ip_address_str : str
+        The IP address to check, as a string.
 
-    Example:
-        >>> is_ip_blocked('192.168.1.1')
-        (True, 'IP address 192.168.1.1 is in blocked range 192.168.0.0/16 (Private network)')
-        >>> is_ip_blocked('8.8.8.8')
-        (False, None)
+    Returns
+    -------
+    Tuple[bool, Optional[str]]
+        ``(True, error_message)`` when the input is in a blocked range
+        or is not a valid IP literal; ``(False, None)`` only when the
+        input is a syntactically valid IP outside every blocked range.
+
+    Examples
+    --------
+    >>> is_ip_blocked('192.168.1.1')
+    (True, 'IP address 192.168.1.1 is in blocked range 192.168.0.0/16 (Private/internal network)')
+    >>> is_ip_blocked('8.8.8.8')
+    (False, None)
+    >>> is_ip_blocked('not-an-ip')
+    (True, 'Invalid IP address: not-an-ip')
     """
     try:
         ip = ipaddress.ip_address(ip_address_str)
-        for network in BLOCKED_IP_RANGES:
-            if ip in network:
-                return True, f"IP address {ip_address_str} is in blocked range {network} (Private/internal network)"
-        return False, None
-    except ValueError as e:
-        # Not a valid IP address
-        return False, None
+    except ValueError:
+        # Fail closed: refuse anything that does not parse as a valid IP
+        # literal so a malformed string cannot slip past the allowlist.
+        return True, f"Invalid IP address: {ip_address_str}"
+
+    for network in BLOCKED_IP_RANGES:
+        if ip in network:
+            return True, f"IP address {ip_address_str} is in blocked range {network} (Private/internal network)"
+    return False, None
 
 
 def validate_host_for_connection(host: str, port: int, allow_private_ips: bool = False) -> Tuple[bool, Optional[str]]:

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -283,3 +283,64 @@ def test_safe_http_fetch_rejects_non_http_scheme(
     assert safe_http_fetch("file:///etc/passwd") is None
     assert safe_http_fetch("ftp://example.com/foo") is None
     assert safe_http_fetch("gopher://example.com/0/x") is None
+
+
+def test_is_ip_blocked_invalid_input_fails_closed() -> None:
+    """
+    A non-IP literal must be reported as blocked, not silently allowed.
+
+    The historical implementation returned ``(False, None)`` for any
+    string that did not parse as an IP, which was a fail-open hole if a
+    malformed value reached :func:`is_ip_blocked` directly. The new
+    behavior is fail-closed.
+    """
+    is_blocked, msg = security_utils.is_ip_blocked("not-an-ip")
+    assert is_blocked is True
+    assert msg is not None
+    assert "Invalid IP address" in msg
+    assert "not-an-ip" in msg
+
+    # Empty string is equally malformed and must also be blocked.
+    is_blocked, msg = security_utils.is_ip_blocked("")
+    assert is_blocked is True
+    assert msg is not None
+    assert "Invalid IP address" in msg
+
+
+def test_is_ip_blocked_valid_public_ip_still_allowed() -> None:
+    """A public IP literal must still pass ``is_ip_blocked`` cleanly."""
+    is_blocked, msg = security_utils.is_ip_blocked("8.8.8.8")
+    assert is_blocked is False
+    assert msg is None
+
+
+def test_is_ip_blocked_private_ip_blocked_with_message() -> None:
+    """A private IP literal must be blocked with a descriptive message."""
+    is_blocked, msg = security_utils.is_ip_blocked("192.168.1.1")
+    assert is_blocked is True
+    assert msg is not None
+    assert "192.168.1.1" in msg
+    assert "192.168.0.0/16" in msg
+
+
+def test_validate_host_blocks_invalid_resolved_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A malformed IP returned by ``getaddrinfo`` must propagate as a
+    blocked verdict from ``validate_host_for_connection`` thanks to
+    ``is_ip_blocked``'s fail-closed posture.
+    """
+    monkeypatch.setenv("ALLOW_INTERNAL_IPS", "false")
+
+    def fake_getaddrinfo(host, port, family, socktype):
+        return [(security_utils.socket.AF_INET, socktype, 0, "", ("not-an-ip", port))]
+
+    monkeypatch.setattr(security_utils.socket, "getaddrinfo", fake_getaddrinfo)
+
+    is_valid, err = security_utils.validate_host_for_connection(
+        "weird.example", 443
+    )
+    assert is_valid is False
+    assert err is not None
+    assert "Invalid IP address" in err

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -195,7 +195,7 @@ def test_safe_http_fetch_rejects_redirect_to_private_ip(
         # Allow only the test server's host:port; everything else goes
         # through the real (strict) validator regardless of the env.
         if host == "127.0.0.1" and p == port:
-            return True, None
+            return True, None, None
         return real_validate(host, p, allow_private_ips=False)
 
     monkeypatch.setattr(
@@ -323,6 +323,64 @@ def test_is_ip_blocked_private_ip_blocked_with_message() -> None:
     assert "192.168.0.0/16" in msg
 
 
+def test_validate_host_returns_resolved_ip_for_hostname(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """For a hostname that resolves to a public IP, the IP is returned for pinning."""
+    monkeypatch.setenv("ALLOW_INTERNAL_IPS", "false")
+
+    def fake_getaddrinfo(host, port, family, socktype):
+        return [
+            (security_utils.socket.AF_INET, socktype, 0, "", ("8.8.8.8", port))
+        ]
+
+    monkeypatch.setattr(security_utils.socket, "getaddrinfo", fake_getaddrinfo)
+
+    is_valid, err, resolved_ip = security_utils.validate_host_for_connection(
+        "dns.google.example", 443
+    )
+    assert is_valid is True
+    assert err is None
+    assert resolved_ip == "8.8.8.8"
+
+
+def test_validate_host_returns_no_pinned_ip_for_ip_literal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An IP literal needs no pinning — there is no DNS step to race."""
+    monkeypatch.setenv("ALLOW_INTERNAL_IPS", "false")
+
+    is_valid, err, resolved_ip = security_utils.validate_host_for_connection(
+        "8.8.8.8", 443
+    )
+    assert is_valid is True
+    assert err is None
+    assert resolved_ip is None
+
+
+def test_validate_host_blocks_when_resolution_includes_private_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ANY resolved IP is private, the whole connection is refused."""
+    monkeypatch.setenv("ALLOW_INTERNAL_IPS", "false")
+
+    def fake_getaddrinfo(host, port, family, socktype):
+        return [
+            (security_utils.socket.AF_INET, socktype, 0, "", ("8.8.8.8", port)),
+            (security_utils.socket.AF_INET, socktype, 0, "", ("127.0.0.1", port)),
+        ]
+
+    monkeypatch.setattr(security_utils.socket, "getaddrinfo", fake_getaddrinfo)
+
+    is_valid, err, resolved_ip = security_utils.validate_host_for_connection(
+        "mixed.example", 443
+    )
+    assert is_valid is False
+    assert err is not None
+    assert "127.0.0.1" in err
+    assert resolved_ip is None
+
+
 def test_validate_host_blocks_invalid_resolved_ip(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -338,9 +396,58 @@ def test_validate_host_blocks_invalid_resolved_ip(
 
     monkeypatch.setattr(security_utils.socket, "getaddrinfo", fake_getaddrinfo)
 
-    is_valid, err = security_utils.validate_host_for_connection(
+    is_valid, err, resolved_ip = security_utils.validate_host_for_connection(
         "weird.example", 443
     )
     assert is_valid is False
     assert err is not None
     assert "Invalid IP address" in err
+    assert resolved_ip is None
+
+
+def test_fetch_leaf_certificate_pins_validated_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Regression test for DNS rebinding: ``fetch_leaf_certificate_and_conn_info``
+    must connect to the IP that ``validate_host_for_connection`` returned,
+    not to whatever DNS resolves to at connect time.
+
+    We make ``validate_host_for_connection`` return the public IP
+    ``8.8.8.8`` (which is what would have been validated upstream), then
+    intercept ``socket.create_connection`` to capture its address
+    argument. The test asserts the captured address is ``("8.8.8.8", port)``
+    — the validated IP — even though a hypothetical attacker could be
+    rebinding DNS to ``127.0.0.1`` in the meantime.
+    """
+    from check_tls import tls_checker
+
+    captured: List[Tuple[str, int]] = []
+
+    def fake_validate(host, port, allow_private_ips=False):
+        # Simulate: hostname resolved to 8.8.8.8 at validation time.
+        return True, None, "8.8.8.8"
+
+    def fake_create_connection(address, timeout=10):
+        captured.append(address)
+        # Raise a clean OSError so the function returns the standard
+        # network-error path without trying a real TLS handshake.
+        raise OSError("intercepted by test")
+
+    monkeypatch.setattr(
+        tls_checker, "validate_host_for_connection", fake_validate
+    )
+    monkeypatch.setattr(
+        tls_checker.socket, "create_connection", fake_create_connection
+    )
+
+    cert, conn_info = tls_checker.fetch_leaf_certificate_and_conn_info(
+        "dns.google.example", port=443, insecure=True
+    )
+
+    assert cert is None
+    assert conn_info is not None
+    assert captured == [("8.8.8.8", 443)], (
+        "create_connection must be pinned to the validated IP, not "
+        "re-resolved from DNS, to defeat rebinding attacks."
+    )


### PR DESCRIPTION
## Summary

Two related security hardening fixes for the SSRF guard added in the previous PRs.

### Fix 1 — `is_ip_blocked` fail-closed on invalid IP

`security_utils.is_ip_blocked` previously returned `(False, None)` when its input did not parse as a valid IP literal. That was fail-open: a malformed string slipping past upstream validation would coast through the SSRF allowlist undetected.

The function now returns `(True, "Invalid IP address: <input>")` for unparsable input, dropping the unused `as e` on the `ValueError` handler and refreshing the docstring example. The change ripples cleanly through `validate_host_for_connection`: if `getaddrinfo` ever surfaces a malformed IP, the caller now receives a clean `(False, error_message)` instead of a silent allow.

### Fix 2 — DNS rebinding mitigation by pinning the validated IP

`validate_host_for_connection` resolved the hostname via `getaddrinfo`, validated the returned IPs, and discarded them. `fetch_leaf_certificate_and_conn_info` then called `socket.create_connection((domain, port))`, which performs its own DNS lookup — a TOCTOU window during which an attacker controlling the authoritative DNS could swap the answer for a private IP (`127.0.0.1`, `169.254.169.254`, etc.).

`validate_host_for_connection` now returns a 3-tuple `(is_valid, error_message, resolved_ip)`. `fetch_leaf_certificate_and_conn_info` pins `socket.create_connection` to the validated IP and keeps `server_hostname=domain` so SNI and hostname matching against the certificate are unaffected. When the host is already an IP literal or `allow_private_ips=True`, `resolved_ip` is `None` and the caller resolves DNS naturally — there is no rebind window in those cases. When `getaddrinfo` returns multiple IPs, all of them are still validated (preserved behavior: any private IP in the set blocks the connection) and the connection is pinned to the first validated address.

#### Trade-off documented in `safe_http_fetch`

`safe_http_fetch` is **not** pinned to the resolved IP. `requests` re-resolves DNS internally, and rewriting the URL to the IP would break HTTPS hostname validation against the certificate. The remaining race window is accepted here because `safe_http_fetch` only retrieves application-layer-signed artefacts — CRLs, OCSP responses, intermediate certificates — and each redirect hop is still re-validated by `validate_host_for_connection`. The trade-off is documented inline in `safe_http_fetch` and in the commit message.

## Commits

- `fix(security): fail closed on invalid IP in is_ip_blocked`
- `fix(security): mitigate DNS rebinding by pinning resolved IP for TLS connect`

## Test plan

- [x] `ALLOW_INTERNAL_IPS=true uv run pytest tests/ -v` — 49 passed
- [x] `uv run --with ruff ruff check src/check_tls/utils/security_utils.py tests/test_security_utils.py` — clean (no new errors; pre-existing F405 wildcard warnings tracked elsewhere)
- [x] `is_ip_blocked` regression: invalid input fails closed, valid public IP allowed, private IP blocked with descriptive message
- [x] `validate_host_for_connection` returns the resolved IP for hostnames, `None` for IP literals, blocks when any resolved IP is private, and propagates fail-closed verdict for malformed `getaddrinfo` answers
- [x] `fetch_leaf_certificate_and_conn_info` regression test pins `create_connection` to the validated IP (does not re-resolve DNS at connect time)
- [x] Existing TLS-checker tests with `ALLOW_INTERNAL_IPS=true` keep working — `(True, None, None)` path is preserved when private IPs are explicitly allowed