### PR TITLE
feat: cert quality warnings + Must-Staple + HSTS

### DIFF
--- a/src/check_tls/main.py
+++ b/src/check_tls/main.py
@@ -199,6 +199,42 @@ def print_human_summary(results):
         else:
             print("  Status      : \033[93mNOT DEFINED\033[0m")
 
+        # HSTS section (HTTP Strict Transport Security, RFC 6797)
+        print("\n\033[1mHSTS:\033[0m")
+        hsts = result.get('hsts', {})
+        if not hsts.get('checked'):
+            print("  Status      : \033[93mSkipped\033[0m")
+        elif hsts.get('error'):
+            print("  Status      : \033[91m❌ Error\033[0m")
+            print(f"  Detail      : \033[91m{hsts['error']}\033[0m")
+        elif not hsts.get('header_present'):
+            print("  Status      : \033[91m❌ No HSTS header\033[0m")
+        else:
+            max_age = hsts.get('max_age')
+            if max_age is None:
+                ma_text = "\033[93mN/A\033[0m"
+            elif max_age == 0:
+                ma_text = "\033[91m0 (HSTS disabled)\033[0m"
+            elif max_age < 60 * 60 * 24 * 180:  # < 6 months
+                ma_text = f"\033[93m{max_age}s\033[0m"
+            else:
+                ma_text = f"\033[92m{max_age}s\033[0m"
+            include_sub = hsts.get('include_subdomains')
+            sub_text = (
+                "\033[92mYes\033[0m" if include_sub else "\033[93mNo\033[0m"
+            )
+            preload = hsts.get('preload')
+            preload_text = (
+                "\033[92mYes\033[0m" if preload else "\033[93mNo\033[0m"
+            )
+            print("  Status      : \033[92m✔️ Header present\033[0m")
+            print(f"  max-age           : {ma_text}")
+            print(f"  includeSubDomains : {sub_text}")
+            print(f"  preload           : {preload_text}")
+            raw = hsts.get('raw_header')
+            if raw:
+                print(f"  Raw         : {raw}")
+
         # Certificate Chain Details
         # Lists details for each certificate in the chain, including intermediates and root.
         # Colorize the count based on whether certificates were found.
@@ -276,6 +312,18 @@ def print_human_summary(results):
                 print(f"      \033[1mSANs:\033[0m {sans_display}")
             else:
                 print(f"      \033[1mSANs:\033[0m None")
+
+            # Must-Staple (RFC 7633): show ✔️ when present, ❌ otherwise.
+            must_staple = cert.get('must_staple')
+            if must_staple is True:
+                print("      \033[1mMust-Staple:\033[0m \033[92m✔️\033[0m")
+            else:
+                print("      \033[1mMust-Staple:\033[0m ❌")
+
+            # Quality warnings (weak key/algorithm)
+            quality_warnings = cert.get('quality_warnings') or []
+            for warning in quality_warnings:
+                print(f"      \033[91m⚠️ {warning}\033[0m")  # Red for severe issues
 
             print("")  # Extra newline for readability between certs
 
@@ -362,6 +410,8 @@ def create_parser():
                         help='Disable OCSP check for the leaf certificate')
     parser.add_argument('--no-caa-check', action='store_true',
                         help='Disable DNS CAA record check')
+    parser.add_argument('--no-hsts-check', action='store_true',
+                        help='Disable HTTP Strict Transport Security (HSTS) header probe')
 
     # Add shtab completion argument using the parser program name
     prog_name = parser.prog  # Get the program name (e.g., 'check-tls')
@@ -448,7 +498,8 @@ def main():
                         skip_transparency=args.no_transparency,
                         perform_crl_check=not args.no_crl_check,
                         perform_ocsp_check=not args.no_ocsp_check,
-                        perform_caa_check=not args.no_caa_check
+                        perform_caa_check=not args.no_caa_check,
+                        perform_hsts_check=not args.no_hsts_check,
                     )
                 )
                 print(" \033[92mdone\033[0m")
@@ -468,7 +519,8 @@ def main():
                 skip_transparency=args.no_transparency,
                 perform_crl_check=not args.no_crl_check,
                 perform_ocsp_check=not args.no_ocsp_check,
-                perform_caa_check=not args.no_caa_check
+                perform_caa_check=not args.no_caa_check,
+                perform_hsts_check=not args.no_hsts_check,
             )
 
 

--- a/src/check_tls/static/js/app.js
+++ b/src/check_tls/static/js/app.js
@@ -163,6 +163,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const leaf = (result.certificates || []).find(c => c.chain_index === 0 && !c.error) || {};
     const transparencyDetailsHtml = renderTransparencyDetailsTable(result.transparency, idx);
     const caaDetailsHtml = renderCaaDetails(result.caa_check, idx);
+    const hstsDetailsHtml = renderHstsDetails(result.hsts, idx);
     const connectionError = result.connection_health && result.connection_health.error;
     // Quick info
     // Determine CSS class for expiry text/badge based on days remaining
@@ -224,11 +225,66 @@ document.addEventListener('DOMContentLoaded', function() {
             </div>
           </div>
           ${caaDetailsHtml}
+          ${hstsDetailsHtml}
           ${transparencyDetailsHtml}
         </div>
       </div>
     `;
     return card;
+  }
+
+  // Render HSTS (RFC 6797) details accordion item.
+  function renderHstsDetails(hstsData, parentIdx) {
+    const headerHtml = (bodyHtml) => `
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="heading-hsts-${parentIdx}">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-hsts-${parentIdx}">
+            HSTS (HTTP Strict Transport Security)
+          </button>
+        </h2>
+        <div id="collapse-hsts-${parentIdx}" class="accordion-collapse collapse" aria-labelledby="heading-hsts-${parentIdx}">
+          <div class="accordion-body">
+            ${bodyHtml}
+          </div>
+        </div>
+      </div>`;
+
+    if (!hstsData || !hstsData.checked) {
+      return headerHtml('<p class="text-muted">HSTS check was skipped.</p>');
+    }
+    if (hstsData.error) {
+      return headerHtml(`<div class="alert alert-danger">${escapeHtml(hstsData.error)}</div>`);
+    }
+    if (!hstsData.header_present) {
+      return headerHtml('<div class="alert alert-danger">No <code>Strict-Transport-Security</code> response header.</div>');
+    }
+
+    const maxAge = hstsData.max_age;
+    let maBadge;
+    if (maxAge === null || maxAge === undefined) {
+      maBadge = '<span class="badge bg-secondary">N/A</span>';
+    } else if (maxAge === 0) {
+      maBadge = '<span class="badge badge-expired">0 (HSTS disabled)</span>';
+    } else if (maxAge < 60 * 60 * 24 * 180) {
+      maBadge = `<span class="badge badge-warning">${maxAge}s</span>`;
+    } else {
+      maBadge = `<span class="badge badge-ok">${maxAge}s</span>`;
+    }
+    const subBadge = hstsData.include_subdomains
+      ? '<span class="badge badge-ok">Yes</span>'
+      : '<span class="badge bg-secondary">No</span>';
+    const preloadBadge = hstsData.preload
+      ? '<span class="badge badge-ok">Yes</span>'
+      : '<span class="badge bg-secondary">No</span>';
+
+    const table = `
+      <table class="table table-sm table-bordered">
+        <tr><th>max-age</th><td>${maBadge}</td></tr>
+        <tr><th>includeSubDomains</th><td>${subBadge}</td></tr>
+        <tr><th>preload</th><td>${preloadBadge}</td></tr>
+        <tr><th>Raw header</th><td><code>${escapeHtml(hstsData.raw_header)}</code></td></tr>
+      </table>`;
+    return headerHtml(table);
   }
 
   // Render Certificate Transparency details table
@@ -389,9 +445,21 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const certs = result.certificates || [];
     if (!certs.length) return `<div class="alert alert-warning">No certificate data available.</div>`;
-    return certs.map((cert, i) => `
+    return certs.map((cert, i) => {
+      // Quality warnings rendered as a Bootstrap alert with one badge per item.
+      const warnings = Array.isArray(cert.quality_warnings) ? cert.quality_warnings : [];
+      const warningsBlock = warnings.length
+        ? `<div class="alert alert-warning py-2 mb-2">${warnings.map(w => `<span class="badge bg-warning text-dark me-1 mb-1">⚠️ ${escapeHtml(w)}</span>`).join('')}</div>`
+        : '';
+      // Must-Staple badge: green when present, secondary otherwise.
+      const mustStapleBadge = cert.must_staple === true
+        ? '<span class="badge bg-success">Must-Staple ✔️</span>'
+        : '<span class="badge bg-secondary">Must-Staple ❌</span>';
+
+      return `
       <h6 class="mt-3 mb-2">Certificate #${i+1} ${cert.chain_index===0 ? '(Leaf)' : (cert.is_ca ? '(CA/Intermediate)' : '(Intermediate)')}</h6>
       ${cert.error ? `<div class="alert alert-danger">${escapeHtml(cert.error)}</div>` : `
+      ${warningsBlock}
       <table class="table table-sm table-bordered mb-3">
         <tr><th>Subject</th>${tdWithTooltip(escapeHtml(cert.subject), "The distinguished name (DN) of the entity to whom the certificate is issued.")}</tr>
         <tr><th>Issuer</th>${tdWithTooltip(escapeHtml(cert.issuer), "The distinguished name (DN) of the entity that signed and issued the certificate.")}</tr>
@@ -403,10 +471,12 @@ document.addEventListener('DOMContentLoaded', function() {
         <tr><th>SHA256 FP</th>${tdWithTooltip(`<span class="fingerprint">${escapeHtml(cert.sha256_fingerprint)}</span>`, "The SHA-256 fingerprint (hash) of the certificate, used to verify its integrity.")}</tr>
         <tr><th>Profile</th>${tdWithTooltip(escapeHtml(cert.profile), "Indicates the certificate profile or type, e.g., DV (Domain Validated), OV (Organization Validated), EV (Extended Validation).")}</tr>
         <tr><th>Is CA</th>${tdWithTooltip(cert.is_ca ? 'Yes' : 'No', "Indicates if this certificate is a Certificate Authority (CA) certificate, meaning it can sign other certificates.")}</tr>
+        <tr><th>Must-Staple</th>${tdWithTooltip(mustStapleBadge, "RFC 7633 TLS Feature extension declaring the holder commits to OCSP stapling.")}</tr>
         <tr><th>SANs</th>${tdWithTooltip(escapeHtml((cert.san || []).join(', ')), "Subject Alternative Names (SANs) are additional hostnames covered by this SSL certificate.")}</tr>
       </table>
       `}
-    `).join('');
+    `;
+    }).join('');
   }
 
   // Handle form submit
@@ -423,6 +493,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const noCrlCheck = formData.get('no_crl_check') === 'true';
     const noOcspCheck = formData.get('no_ocsp_check') === 'true';
     const noCaaCheck = formData.get('no_caa_check') === 'true';
+    const noHstsCheck = formData.get('no_hsts_check') === 'true';
 
     const payload = {
       domains: domainsArray,
@@ -431,7 +502,8 @@ document.addEventListener('DOMContentLoaded', function() {
       no_transparency: noTransparency,
       no_crl_check: noCrlCheck,
       no_ocsp_check: noOcspCheck,
-      no_caa_check: noCaaCheck
+      no_caa_check: noCaaCheck,
+      no_hsts_check: noHstsCheck
     };
 
     fetch('/api/analyze', {

--- a/src/check_tls/templates/index.html
+++ b/src/check_tls/templates/index.html
@@ -52,6 +52,10 @@
             <input class="form-check-input" type="checkbox" id="no_caa_check" name="no_caa_check" value="true">
             <label class="form-check-label" for="no_caa_check">Disable CAA Check</label>
           </div>
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="no_hsts_check" name="no_hsts_check" value="true">
+            <label class="form-check-label" for="no_hsts_check">Disable HSTS Check</label>
+          </div>
         </div>
       </div>
     </div>

--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -22,6 +22,7 @@ from check_tls.utils.crl_utils import check_crl
 from check_tls.utils.crtsh_utils import query_crtsh_multi
 from check_tls.utils.dns_utils import query_caa
 from check_tls.utils.domain_parser import parse_domain_entry
+from check_tls.utils.hsts_utils import check_hsts
 from check_tls.utils.security_utils import safe_http_fetch, validate_host_for_connection
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -474,7 +475,7 @@ def detect_profile(cert: x509.Certificate) -> str:
 
     return profile
 
-def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insecure: bool = False, skip_transparency: bool = False, perform_crl_check: bool = True, perform_ocsp_check: bool = True, perform_caa_check: bool = True) -> dict:
+def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insecure: bool = False, skip_transparency: bool = False, perform_crl_check: bool = True, perform_ocsp_check: bool = True, perform_caa_check: bool = True, perform_hsts_check: bool = True) -> dict:
     """
     Analyze the certificates of a domain, including leaf and intermediate certificates,
     perform validation, CRL, OCSP checks, and certificate transparency checks.
@@ -488,6 +489,8 @@ def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insec
         perform_crl_check (bool): Whether to perform Certificate Revocation List (CRL) checks.
         perform_ocsp_check (bool): Whether to perform Online Certificate Status Protocol (OCSP) checks.
         perform_caa_check (bool): Whether to check DNS CAA records.
+        perform_hsts_check (bool): Whether to probe the HTTP Strict Transport
+            Security policy via an HTTPS HEAD request.
 
     Returns:
         dict: A dictionary containing analysis results, including connection info,
@@ -532,6 +535,15 @@ def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insec
             "checked": False,
             "found": None,
             "records": None,
+            "error": None,
+        },
+        "hsts": {
+            "checked": False,
+            "header_present": False,
+            "max_age": None,
+            "include_subdomains": False,
+            "preload": False,
+            "raw_header": None,
             "error": None,
         },
     }
@@ -703,6 +715,21 @@ def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insec
         logger.info(f"Skipping DNS CAA check for {domain} as requested.")
         result["caa_check"]["checked"] = False
 
+    # HSTS check (RFC 6797). Only attempt when the leaf certificate
+    # was retrieved successfully — there is no point hitting HTTPS
+    # again if the TLS handshake itself failed.
+    if perform_hsts_check:
+        logger.info(f"Checking HSTS policy for {domain}...")
+        try:
+            hsts_info = check_hsts(domain, port=port)
+            result["hsts"].update(hsts_info)
+        except Exception as e:
+            logger.warning(f"Unexpected error during HSTS check for {domain}: {e}")
+            result["hsts"].update({"checked": True, "error": str(e)})
+    else:
+        logger.info(f"Skipping HSTS check for {domain} as requested.")
+        result["hsts"]["checked"] = False
+
     # Certificate Transparency check (domain + parent domains)
     if not skip_transparency:
         ct_results = query_crtsh_multi(domain)
@@ -747,7 +774,7 @@ def get_log_level(level_str: str):
     """
     return getattr(logging, level_str.upper(), logging.WARNING)
 
-def run_analysis(domains_input: List[str], output_json: Optional[str] = None, output_csv: Optional[str] = None, mode: str = "full", insecure: bool = False, skip_transparency: bool = False, perform_crl_check: bool = True, perform_ocsp_check: bool = True, perform_caa_check: bool = True):
+def run_analysis(domains_input: List[str], output_json: Optional[str] = None, output_csv: Optional[str] = None, mode: str = "full", insecure: bool = False, skip_transparency: bool = False, perform_crl_check: bool = True, perform_ocsp_check: bool = True, perform_caa_check: bool = True, perform_hsts_check: bool = True):
     """
     Run TLS analysis for a list of domains (which can include ports) and output results.
 
@@ -761,6 +788,7 @@ def run_analysis(domains_input: List[str], output_json: Optional[str] = None, ou
         perform_crl_check (bool): Perform CRL checks.
         perform_ocsp_check (bool): Perform OCSP checks.
         perform_caa_check (bool): Perform DNS CAA checks.
+        perform_hsts_check (bool): Probe HTTP Strict Transport Security policy.
     """
     logger = logging.getLogger("certcheck")
     results = [] # Changed from all_results to results to match original variable name
@@ -788,6 +816,7 @@ def run_analysis(domains_input: List[str], output_json: Optional[str] = None, ou
                 perform_crl_check=perform_crl_check,
                 perform_ocsp_check=perform_ocsp_check,
                 perform_caa_check=perform_caa_check,
+                perform_hsts_check=perform_hsts_check,
             )
         except Exception as e:
             analysis_ts = datetime.datetime.now(timezone.utc).isoformat()
@@ -817,6 +846,15 @@ def run_analysis(domains_input: List[str], output_json: Optional[str] = None, ou
                     "checked": perform_caa_check,
                     "found": None,
                     "records": None,
+                    "error": str(e),
+                },
+                "hsts": {
+                    "checked": perform_hsts_check,
+                    "header_present": False,
+                    "max_age": None,
+                    "include_subdomains": False,
+                    "preload": False,
+                    "raw_header": None,
                     "error": str(e),
                 },
             }

--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -629,6 +629,7 @@ def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insec
                 "has_scts": has_scts(cert),
                 "is_ca": is_ca,
                 "path_length_constraint": path_len,
+                "quality_warnings": assess_cert_quality(cert),
             }
             result["certificates"].append(cert_data)
         except Exception as e:

--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -630,6 +630,7 @@ def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insec
                 "is_ca": is_ca,
                 "path_length_constraint": path_len,
                 "quality_warnings": assess_cert_quality(cert),
+                "must_staple": has_must_staple(cert),
             }
             result["certificates"].append(cert_data)
         except Exception as e:

--- a/src/check_tls/utils/cert_utils.py
+++ b/src/check_tls/utils/cert_utils.py
@@ -252,6 +252,79 @@ def assess_cert_quality(cert: x509.Certificate) -> List[str]:
     return warnings
 
 
+# ---------------------------------------------------------------------------
+# RFC 7633 — TLS Feature extension (a.k.a. "Must-Staple")
+# ---------------------------------------------------------------------------
+TLS_FEATURE_OID = ObjectIdentifier("1.3.6.1.5.5.7.1.24")
+
+
+def has_must_staple(cert: x509.Certificate) -> bool:
+    """
+    Return ``True`` when the TLS Feature extension declares ``status_request``.
+
+    The TLS Feature extension (RFC 7633) is an X.509 extension whose
+    value is an ASN.1 ``SEQUENCE OF INTEGER``. When the integer ``5``
+    (``status_request``) appears in the sequence the certificate
+    declares that the holder commits to OCSP stapling, commonly
+    referred to as "Must-Staple".
+
+    Detection strategy:
+
+    1. Try the typed accessor exposed by recent ``cryptography``
+       releases (``ext.value`` is iterable over ``TLSFeatureType`` enum
+       members whose ``.value`` is the integer feature id).
+    2. Otherwise fall back to scanning the raw DER bytes of the
+       extension value for the literal three-byte marker
+       ``02 01 05`` — the DER encoding of ``INTEGER 5``. Because the
+       value is an ASN.1 sequence of single-byte integers, a substring
+       match is sufficient and unambiguous.
+
+    Parameters
+    ----------
+    cert : x509.Certificate
+        The certificate to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` if the TLS Feature extension is present and contains
+        ``status_request`` (5); ``False`` otherwise (extension absent,
+        empty, or does not contain feature 5).
+    """
+    try:
+        ext = cert.extensions.get_extension_for_oid(TLS_FEATURE_OID)
+    except x509.ExtensionNotFound:
+        return False
+    except Exception:
+        return False
+
+    # cryptography exposes a typed ``TLSFeature`` extension that is
+    # iterable over ``TLSFeatureType`` enum members (integer-valued).
+    # Older releases that do not decode this OID natively expose the
+    # raw DER bytes via ``UnrecognizedExtension.value``.
+    value = ext.value
+    try:
+        for feature in iter(value):
+            try:
+                feature_int = int(getattr(feature, "value", feature))
+            except (TypeError, ValueError):
+                continue
+            if feature_int == 5:
+                return True
+        return False
+    except TypeError:
+        # ``value`` is not iterable — likely an UnrecognizedExtension
+        # because the running ``cryptography`` does not decode this OID.
+        pass
+
+    # Raw-DER fallback: the value is ``SEQUENCE OF INTEGER`` so each
+    # feature appears as ``02 01 <id>`` (DER tag, length, content).
+    raw = getattr(value, "value", None)
+    if isinstance(raw, (bytes, bytearray)):
+        return b"\x02\x01\x05" in bytes(raw)
+    return False
+
+
 def get_common_name(subject: x509.Name) -> Optional[str]:
     """
     Retrieves the Common Name (CN) from the subject of a certificate.

--- a/src/check_tls/utils/cert_utils.py
+++ b/src/check_tls/utils/cert_utils.py
@@ -182,6 +182,76 @@ def extract_san(cert: x509.Certificate) -> List[str]:
         return []
 
 
+def assess_cert_quality(cert: x509.Certificate) -> List[str]:
+    """
+    Return a list of human-readable quality warnings for a certificate.
+
+    Inspects the certificate's public key (algorithm, size/curve) and
+    signature hash algorithm and emits one warning per detected
+    weakness. An empty list means no issues were detected at the
+    algorithm/key-strength level.
+
+    The following situations trigger a warning:
+
+    - **RSA key < 2048 bits**: ``"Weak RSA key: <size> bits (recommended >= 2048)"``.
+    - **ECDSA curve < P-256** (i.e. ``key_size`` < 256):
+      ``"Weak ECDSA curve: <curve_name> (recommended >= P-256)"``.
+    - **DSA public key**: ``"Deprecated DSA key (use RSA or ECDSA)"`` —
+      regardless of size; DSA is no longer recommended for TLS.
+    - **SHA-1 signature**: ``"Deprecated signature algorithm: sha1"``.
+    - **MD5 / MD2 / MD4 signature**: ``"Insecure signature algorithm: <name>"``.
+
+    Parameters
+    ----------
+    cert : x509.Certificate
+        The certificate to assess.
+
+    Returns
+    -------
+    List[str]
+        Quality warnings, possibly empty.
+
+    Examples
+    --------
+    >>> warnings = assess_cert_quality(cert)
+    >>> if warnings:
+    ...     for w in warnings:
+    ...         print("WARN:", w)
+    """
+    warnings: List[str] = []
+
+    public_key = cert.public_key()
+
+    # Public-key strength checks. ``isinstance`` matches the order used
+    # in :func:`get_public_key_details` so behaviour stays consistent.
+    if isinstance(public_key, rsa.RSAPublicKey):
+        if public_key.key_size < 2048:
+            warnings.append(
+                f"Weak RSA key: {public_key.key_size} bits (recommended >= 2048)"
+            )
+    elif isinstance(public_key, ec.EllipticCurvePublicKey):
+        curve_size = public_key.curve.key_size
+        if curve_size < 256:
+            curve_name = getattr(public_key.curve, "name", "unknown") or "unknown"
+            warnings.append(
+                f"Weak ECDSA curve: {curve_name} (recommended >= P-256)"
+            )
+    elif isinstance(public_key, dsa.DSAPublicKey):
+        warnings.append("Deprecated DSA key (use RSA or ECDSA)")
+
+    # Signature hash algorithm checks. ``signature_hash_algorithm`` may
+    # be ``None`` for some non-standard certificates (e.g. Ed25519).
+    sig_algo = cert.signature_hash_algorithm
+    if sig_algo is not None:
+        sig_name = sig_algo.name.lower()
+        if sig_name == "sha1":
+            warnings.append("Deprecated signature algorithm: sha1")
+        elif sig_name in {"md5", "md2", "md4"}:
+            warnings.append(f"Insecure signature algorithm: {sig_name}")
+
+    return warnings
+
+
 def get_common_name(subject: x509.Name) -> Optional[str]:
     """
     Retrieves the Common Name (CN) from the subject of a certificate.

--- a/src/check_tls/utils/hsts_utils.py
+++ b/src/check_tls/utils/hsts_utils.py
@@ -1,0 +1,144 @@
+"""
+hsts_utils.py
+=============
+
+HTTP Strict Transport Security (HSTS) inspection utilities.
+
+Provides :func:`check_hsts` which performs an HTTPS ``HEAD`` request to a
+domain via :func:`safe_http_fetch` (so SSRF protection is honored) and
+returns a parsed view of the ``Strict-Transport-Security`` response
+header per RFC 6797.
+"""
+
+from typing import Any, Dict, Optional
+
+from check_tls.utils.security_utils import safe_http_fetch
+
+
+def _parse_hsts_header(header_value: str) -> Dict[str, Any]:
+    """
+    Parse a ``Strict-Transport-Security`` header value per RFC 6797.
+
+    Directive names are matched case-insensitively. Values may be
+    quoted (``max-age="31536000"``) and surrounding whitespace is
+    tolerated.
+
+    Parameters
+    ----------
+    header_value : str
+        The raw header value (without the field name).
+
+    Returns
+    -------
+    Dict[str, Any]
+        Parsed values with keys:
+
+        - ``max_age`` (Optional[int])
+        - ``include_subdomains`` (bool)
+        - ``preload`` (bool)
+    """
+    parsed: Dict[str, Any] = {
+        "max_age": None,
+        "include_subdomains": False,
+        "preload": False,
+    }
+
+    for raw_directive in header_value.split(";"):
+        directive = raw_directive.strip()
+        if not directive:
+            continue
+        if "=" in directive:
+            name, _, value = directive.partition("=")
+            name = name.strip().lower()
+            value = value.strip().strip('"').strip("'")
+            if name == "max-age":
+                try:
+                    parsed["max_age"] = int(value)
+                except ValueError:
+                    parsed["max_age"] = None
+        else:
+            name = directive.lower()
+            if name == "includesubdomains":
+                parsed["include_subdomains"] = True
+            elif name == "preload":
+                parsed["preload"] = True
+
+    return parsed
+
+
+def check_hsts(domain: str, port: int = 443) -> Dict[str, Any]:
+    """
+    Probe a domain for an HTTP Strict Transport Security policy.
+
+    Issues an HTTPS ``HEAD`` request to ``https://<domain>:<port>/``
+    via :func:`safe_http_fetch` (which enforces SSRF protections and
+    re-validates each redirect hop) and inspects the
+    ``Strict-Transport-Security`` response header.
+
+    Parameters
+    ----------
+    domain : str
+        Hostname to probe.
+    port : int, optional
+        TCP port to use in the HTTPS URL. Defaults to ``443``.
+
+    Returns
+    -------
+    Dict[str, Any]
+        A dictionary with the following keys:
+
+        - ``checked`` (bool): always ``True`` — this function ran.
+        - ``header_present`` (bool): ``True`` when an HSTS header
+          was returned by the server.
+        - ``max_age`` (Optional[int]): parsed ``max-age`` directive.
+        - ``include_subdomains`` (bool): ``True`` when
+          ``includeSubDomains`` is set.
+        - ``preload`` (bool): ``True`` when ``preload`` is set.
+        - ``raw_header`` (Optional[str]): the unparsed header value.
+        - ``error`` (Optional[str]): non-``None`` when the HEAD
+          request could not be performed.
+
+    Examples
+    --------
+    >>> result = check_hsts("example.com")  # doctest: +SKIP
+    >>> result["header_present"]
+    True
+    """
+    result: Dict[str, Any] = {
+        "checked": True,
+        "header_present": False,
+        "max_age": None,
+        "include_subdomains": False,
+        "preload": False,
+        "raw_header": None,
+        "error": None,
+    }
+
+    # Build the target URL. Omit the explicit port when 443 to avoid
+    # confusing servers that vary content based on Host header.
+    if port == 443:
+        url = f"https://{domain}/"
+    else:
+        url = f"https://{domain}:{port}/"
+
+    response = safe_http_fetch(url, method="HEAD")
+    if response is None:
+        result["error"] = (
+            "HSTS check failed: HEAD request was rejected, errored out, "
+            "or returned a non-success status."
+        )
+        return result
+
+    header_value: Optional[str] = response.headers.get("Strict-Transport-Security")
+    if not header_value:
+        return result
+
+    result["header_present"] = True
+    result["raw_header"] = header_value
+
+    parsed = _parse_hsts_header(header_value)
+    result["max_age"] = parsed["max_age"]
+    result["include_subdomains"] = parsed["include_subdomains"]
+    result["preload"] = parsed["preload"]
+
+    return result

--- a/src/check_tls/web_server.py
+++ b/src/check_tls/web_server.py
@@ -49,7 +49,7 @@ def get_flask_app():
     app = Flask(__name__,
                 template_folder=os.path.join(project_root, 'templates'),
                 static_folder=os.path.join(project_root, 'static'))
-    app.config['SCRIPT_ARGS'] = argparse.Namespace(insecure=False, no_transparency=False, no_crl_check=False, no_caa_check=False, connect_port=443)
+    app.config['SCRIPT_ARGS'] = argparse.Namespace(insecure=False, no_transparency=False, no_crl_check=False, no_caa_check=False, no_hsts_check=False, connect_port=443)
 
     @app.after_request
     def _set_security_headers(response):
@@ -164,6 +164,7 @@ def get_flask_app():
         no_crl_check_flag = bool(data.get('no_crl_check', False))
         no_ocsp_check_flag = bool(data.get('no_ocsp_check', False))
         no_caa_check_flag = bool(data.get('no_caa_check', False))
+        no_hsts_check_flag = bool(data.get('no_hsts_check', False))
 
         try:
             connect_port_from_json = int(data.get('connect_port', 443))
@@ -182,11 +183,13 @@ def get_flask_app():
                 skip_transparency=no_transparency_flag,
                 perform_crl_check=not no_crl_check_flag,
                 perform_ocsp_check=not no_ocsp_check_flag,
-                perform_caa_check=not no_caa_check_flag
+                perform_caa_check=not no_caa_check_flag,
+                perform_hsts_check=not no_hsts_check_flag,
             )
             # Include OCSP results in JSON API
             analysis_result["ocsp_check"] = analysis_result.get("ocsp_check", {})
             analysis_result["caa_check"] = analysis_result.get("caa_check", {})
+            analysis_result["hsts"] = analysis_result.get("hsts", {})
             results.append(analysis_result)
         return jsonify(results)
     return app

--- a/tests/test_cert_quality.py
+++ b/tests/test_cert_quality.py
@@ -1,0 +1,137 @@
+"""Tests for :func:`check_tls.utils.cert_utils.assess_cert_quality`."""
+
+import datetime
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
+
+from check_tls.utils.cert_utils import assess_cert_quality
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_cert(public_key, signing_key, sign_algo=hashes.SHA256()):
+    """
+    Build a minimal x509 certificate carrying ``public_key``, signed
+    with ``signing_key`` using ``sign_algo``.
+
+    Used to vary key types/sizes and signature algorithms in tests.
+    """
+    name = x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "test")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(public_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+    )
+    return builder.sign(signing_key, sign_algo)
+
+
+class _FakeSigAlgo:
+    """Duck-typed object with a ``name`` attribute, used to spoof
+    :attr:`x509.Certificate.signature_hash_algorithm` so the SHA-1 /
+    MD5 paths can be exercised without asking ``cryptography`` to
+    actually sign with those (forbidden) hashes."""
+
+    def __init__(self, name):
+        self.name = name
+
+
+class _CertProxy:
+    """Wrap a real certificate but override ``signature_hash_algorithm``."""
+
+    def __init__(self, real_cert, fake_sig_name):
+        self._real = real_cert
+        self._fake = _FakeSigAlgo(fake_sig_name)
+
+    @property
+    def signature_hash_algorithm(self):
+        return self._fake
+
+    def public_key(self):
+        return self._real.public_key()
+
+
+# ---------------------------------------------------------------------------
+# Public-key strength
+# ---------------------------------------------------------------------------
+
+def test_rsa_1024_emits_weak_warning():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=1024)
+    cert = _build_cert(key.public_key(), key)
+    warnings = assess_cert_quality(cert)
+    assert any("Weak RSA key: 1024 bits" in w for w in warnings)
+
+
+def test_rsa_2048_is_clean():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    cert = _build_cert(key.public_key(), key)
+    assert assess_cert_quality(cert) == []
+
+
+def test_ecdsa_p192_emits_weak_warning():
+    key = ec.generate_private_key(ec.SECP192R1())
+    # ECDSA cannot sign with SHA-256 in some constrained builds; use
+    # SHA-256 directly which is still acceptable for SECP192R1.
+    cert = _build_cert(key.public_key(), key, hashes.SHA256())
+    warnings = assess_cert_quality(cert)
+    assert any("Weak ECDSA curve" in w for w in warnings)
+
+
+def test_ecdsa_p256_is_clean():
+    key = ec.generate_private_key(ec.SECP256R1())
+    cert = _build_cert(key.public_key(), key, hashes.SHA256())
+    assert assess_cert_quality(cert) == []
+
+
+def test_dsa_emits_deprecated_warning():
+    # DSA at 2048 bits — still flagged because DSA itself is deprecated
+    # for TLS regardless of size.
+    dsa_key = dsa.generate_private_key(key_size=2048)
+    rsa_signer = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    cert = _build_cert(dsa_key.public_key(), rsa_signer)
+    warnings = assess_cert_quality(cert)
+    assert any("Deprecated DSA key" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Signature hash algorithm
+# ---------------------------------------------------------------------------
+
+def test_sha1_signature_emits_deprecated_warning():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    cert = _build_cert(key.public_key(), key)
+    proxy = _CertProxy(cert, "sha1")
+    warnings = assess_cert_quality(proxy)
+    assert any("Deprecated signature algorithm: sha1" in w for w in warnings)
+
+
+def test_md5_signature_emits_insecure_warning():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    cert = _build_cert(key.public_key(), key)
+    proxy = _CertProxy(cert, "md5")
+    warnings = assess_cert_quality(proxy)
+    assert any("Insecure signature algorithm: md5" in w for w in warnings)
+
+
+def test_sha256_signature_is_clean():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    cert = _build_cert(key.public_key(), key, hashes.SHA256())
+    assert assess_cert_quality(cert) == []
+
+
+def test_combined_weak_key_and_weak_sig_emits_two_warnings():
+    rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=1024)
+    cert = _build_cert(rsa_key.public_key(), rsa_key)
+    proxy = _CertProxy(cert, "sha1")
+    warnings = assess_cert_quality(proxy)
+    assert any("Weak RSA key" in w for w in warnings)
+    assert any("Deprecated signature algorithm: sha1" in w for w in warnings)
+    assert len(warnings) == 2

--- a/tests/test_hsts_utils.py
+++ b/tests/test_hsts_utils.py
@@ -1,0 +1,162 @@
+"""Tests for :mod:`check_tls.utils.hsts_utils`."""
+
+from typing import Optional
+
+from check_tls.utils import hsts_utils
+from check_tls.utils.hsts_utils import _parse_hsts_header, check_hsts
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    """Minimal stand-in for :class:`requests.Response` that exposes
+    just the ``headers`` mapping consumed by :func:`check_hsts`."""
+
+    def __init__(self, header_value: Optional[str] = None):
+        self.headers = {}
+        if header_value is not None:
+            self.headers["Strict-Transport-Security"] = header_value
+
+
+# ---------------------------------------------------------------------------
+# Header parser
+# ---------------------------------------------------------------------------
+
+def test_parse_full_directive_set():
+    parsed = _parse_hsts_header(
+        "max-age=31536000; includeSubDomains; preload"
+    )
+    assert parsed == {
+        "max_age": 31536000,
+        "include_subdomains": True,
+        "preload": True,
+    }
+
+
+def test_parse_quoted_max_age():
+    parsed = _parse_hsts_header('max-age="63072000"; includeSubDomains')
+    assert parsed["max_age"] == 63072000
+    assert parsed["include_subdomains"] is True
+    assert parsed["preload"] is False
+
+
+def test_parse_directive_matching_is_case_insensitive():
+    parsed = _parse_hsts_header(
+        "MAX-AGE=10; INCLUDESUBDOMAINS; PRELOAD"
+    )
+    assert parsed == {
+        "max_age": 10,
+        "include_subdomains": True,
+        "preload": True,
+    }
+
+
+def test_parse_zero_max_age():
+    parsed = _parse_hsts_header("max-age=0")
+    assert parsed["max_age"] == 0
+    assert parsed["include_subdomains"] is False
+    assert parsed["preload"] is False
+
+
+def test_parse_malformed_max_age_yields_none():
+    parsed = _parse_hsts_header("max-age=notanumber; preload")
+    assert parsed["max_age"] is None
+    assert parsed["preload"] is True
+
+
+def test_parse_empty_string():
+    assert _parse_hsts_header("") == {
+        "max_age": None,
+        "include_subdomains": False,
+        "preload": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# check_hsts
+# ---------------------------------------------------------------------------
+
+def test_check_hsts_full_policy(monkeypatch):
+    captured = {}
+
+    def fake_fetch(url, *, method="GET", **kwargs):
+        captured["url"] = url
+        captured["method"] = method
+        return _FakeResponse(
+            "max-age=31536000; includeSubDomains; preload"
+        )
+
+    monkeypatch.setattr(hsts_utils, "safe_http_fetch", fake_fetch)
+    result = check_hsts("example.com")
+
+    assert captured["url"] == "https://example.com/"
+    assert captured["method"] == "HEAD"
+    assert result["checked"] is True
+    assert result["header_present"] is True
+    assert result["max_age"] == 31536000
+    assert result["include_subdomains"] is True
+    assert result["preload"] is True
+    assert result["error"] is None
+
+
+def test_check_hsts_custom_port_in_url(monkeypatch):
+    captured = {}
+
+    def fake_fetch(url, *, method="GET", **kwargs):
+        captured["url"] = url
+        return _FakeResponse("max-age=600")
+
+    monkeypatch.setattr(hsts_utils, "safe_http_fetch", fake_fetch)
+    check_hsts("example.com", port=8443)
+    assert captured["url"] == "https://example.com:8443/"
+
+
+def test_check_hsts_no_header(monkeypatch):
+    monkeypatch.setattr(
+        hsts_utils, "safe_http_fetch", lambda *a, **k: _FakeResponse(None)
+    )
+    result = check_hsts("example.com")
+    assert result["header_present"] is False
+    assert result["max_age"] is None
+    assert result["include_subdomains"] is False
+    assert result["preload"] is False
+    assert result["error"] is None
+    assert result["raw_header"] is None
+
+
+def test_check_hsts_fetch_failure_returns_error(monkeypatch):
+    monkeypatch.setattr(
+        hsts_utils, "safe_http_fetch", lambda *a, **k: None
+    )
+    result = check_hsts("blocked.example")
+    assert result["checked"] is True
+    assert result["header_present"] is False
+    assert result["error"] is not None
+    assert "HSTS check failed" in result["error"]
+
+
+def test_check_hsts_zero_max_age(monkeypatch):
+    monkeypatch.setattr(
+        hsts_utils,
+        "safe_http_fetch",
+        lambda *a, **k: _FakeResponse("max-age=0"),
+    )
+    result = check_hsts("example.com")
+    assert result["header_present"] is True
+    assert result["max_age"] == 0
+    assert result["raw_header"] == "max-age=0"
+
+
+def test_check_hsts_malformed_header(monkeypatch):
+    monkeypatch.setattr(
+        hsts_utils,
+        "safe_http_fetch",
+        lambda *a, **k: _FakeResponse("garbage; max-age=oops"),
+    )
+    result = check_hsts("example.com")
+    assert result["header_present"] is True
+    assert result["max_age"] is None
+    assert result["include_subdomains"] is False
+    assert result["preload"] is False

--- a/tests/test_must_staple.py
+++ b/tests/test_must_staple.py
@@ -1,0 +1,65 @@
+"""Tests for :func:`check_tls.utils.cert_utils.has_must_staple`."""
+
+import datetime
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509 import TLSFeature, TLSFeatureType
+
+from check_tls.utils.cert_utils import has_must_staple
+
+
+def _build_cert(extensions):
+    """Build a self-signed RSA cert carrying the given extensions."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(x509.oid.NameOID.COMMON_NAME, "test")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+    )
+    for ext, critical in extensions:
+        builder = builder.add_extension(ext, critical=critical)
+    return builder.sign(key, hashes.SHA256())
+
+
+def test_has_must_staple_true_when_status_request_present():
+    cert = _build_cert(
+        [(TLSFeature(features=[TLSFeatureType.status_request]), False)]
+    )
+    assert has_must_staple(cert) is True
+
+
+def test_has_must_staple_false_without_extension():
+    cert = _build_cert([])
+    assert has_must_staple(cert) is False
+
+
+def test_has_must_staple_false_with_status_request_v2_only():
+    """Only the integer 5 (status_request) qualifies as Must-Staple;
+    status_request_v2 (17) does not."""
+    cert = _build_cert(
+        [(TLSFeature(features=[TLSFeatureType.status_request_v2]), False)]
+    )
+    assert has_must_staple(cert) is False
+
+
+def test_has_must_staple_true_when_both_features_present():
+    cert = _build_cert(
+        [(
+            TLSFeature(
+                features=[
+                    TLSFeatureType.status_request,
+                    TLSFeatureType.status_request_v2,
+                ]
+            ),
+            False,
+        )]
+    )
+    assert has_must_staple(cert) is True


### PR DESCRIPTION
## Summary

Three new analyses are surfaced in both the CLI summary and the web UI, plus the JSON API.

### 1. Per-certificate quality warnings

`assess_cert_quality()` (in `cert_utils.py`) inspects each certificate in the chain and emits a warning per detected weakness:

| Trigger | Warning |
|---|---|
| RSA key < 2048 bits | `Weak RSA key: <size> bits (recommended >= 2048)` |
| ECDSA curve < P-256 | `Weak ECDSA curve: <curve_name> (recommended >= P-256)` |
| Signature algorithm SHA-1 | `Deprecated signature algorithm: sha1` |
| Signature algorithm MD5/MD2/MD4 | `Insecure signature algorithm: <name>` |
| DSA public key (any size) | `Deprecated DSA key (use RSA or ECDSA)` |

Surfaced as `result["certificates"][i]["quality_warnings"]: List[str]` (empty list = no issues).

### 2. Must-Staple detection (RFC 7633)

`has_must_staple()` detects the TLS Feature extension (OID `1.3.6.1.5.5.7.1.24`) carrying `status_request` (feature `5`). The detection tries the typed `TLSFeature` accessor exposed by recent `cryptography` releases, then falls back to scanning the raw DER bytes for the `02 01 05` `INTEGER 5` marker so detection still works on older releases that do not decode this OID natively.

Surfaced as `result["certificates"][i]["must_staple"]: bool`.

### 3. HSTS check (RFC 6797)

New utility module `check_tls.utils.hsts_utils` exposes `check_hsts(domain, port=443) -> Dict[str, Any]` which issues an HTTPS `HEAD` request through `safe_http_fetch` (so SSRF protections still apply) and parses the `Strict-Transport-Security` response header per RFC 6797 — directives are matched case-insensitively, quoted values are tolerated.

Surfaced as a new top-level result field:

```python
result["hsts"] = {
    "checked": bool,
    "header_present": bool,
    "max_age": Optional[int],
    "include_subdomains": bool,
    "preload": bool,
    "raw_header": Optional[str],
    "error": Optional[str],
}
```

Skipped when the new `perform_hsts_check` flag is `False` or the underlying `analyze_certificates` already failed before entering the HSTS path. CLI flag `--no-hsts-check` (default: enabled). API flag `no_hsts_check` (default: `false`).

## CLI / Web surfacing

- CLI: per-cert lines now emit `Must-Staple: ✔️/❌` and a red `⚠️` block per quality warning. New top-level `HSTS:` section between CAA and the chain dump, with color-coded `max-age` (red=0, yellow <6mo, green >=6mo) and the raw header echoed.
- Web: per-cert Bootstrap alert with one badge per quality warning + a `Must-Staple` row in the chain table. New `HSTS` accordion section after CAA with parsed `max-age` / `includeSubDomains` / `preload` and the raw header. New `Disable HSTS Check` checkbox in the form.

## RFCs

- RFC 6797 — HTTP Strict Transport Security: <https://datatracker.ietf.org/doc/html/rfc6797>
- RFC 7633 — X.509v3 TLS Feature Extension (Must-Staple): <https://datatracker.ietf.org/doc/html/rfc7633>

## Test plan

- [x] `ALLOW_INTERNAL_IPS=true uv run pytest tests/ -v` — 66/66 passing
  - 25 new tests across `test_cert_quality.py`, `test_must_staple.py`, `test_hsts_utils.py`
  - 41 pre-existing tests still green (Hostname mismatch, expired-cert, wildcard SAN, self-signed chain, security-utils, web-server CSP, etc.)
- [x] `uv run --with ruff ruff check src/ tests/` — no NEW errors compared to `main` (pre-existing F401/F403/F405/F541/F841 baseline preserved as documented in the task)
- [ ] Manual smoke test against a live HSTS-preloaded host (e.g. `python -m check_tls.main github.com`) — recommended on review
- [ ] Manual web UI smoke (`python -m check_tls.main --server -p 8000`) to confirm the HSTS accordion + per-cert warning badges render