### PR TITLE
feat(tls): split fetch_leaf + ALPN + STARTTLS support

### DIFF
--- a/src/check_tls/main.py
+++ b/src/check_tls/main.py
@@ -54,6 +54,15 @@ def print_human_summary(results):
             )
             print(f"  TLS 1.3     : {tls13_text}")
             print(f"  Cipher Suite: {conn.get('cipher_suite', 'N/A')}")
+            # ALPN: green when h2 negotiated, default otherwise.
+            alpn = conn.get('alpn_protocol')
+            if alpn == 'h2':
+                alpn_text = '\033[92mh2\033[0m'
+            elif alpn:
+                alpn_text = alpn
+            else:
+                alpn_text = '\033[93mN/A\033[0m'
+            print(f"  ALPN        : {alpn_text}")
             # Print connection error if present (uses red color \033[91m)
             if conn.get('error'):
                 print(f"  Error       : \033[91m{conn['error']}\033[0m")
@@ -412,6 +421,10 @@ def create_parser():
                         help='Disable DNS CAA record check')
     parser.add_argument('--no-hsts-check', action='store_true',
                         help='Disable HTTP Strict Transport Security (HSTS) header probe')
+    parser.add_argument('--starttls', type=str, choices=['smtp', 'imap', 'pop3', 'ldap'], default=None,
+                        help=("Negotiate STARTTLS for the given plaintext protocol before TLS. "
+                              "When set with no explicit port, the protocol's default port is used "
+                              "(smtp=25, imap=143, pop3=110). 'ldap' is reserved and emits a clear error."))
 
     # Add shtab completion argument using the parser program name
     prog_name = parser.prog  # Get the program name (e.g., 'check-tls')
@@ -459,6 +472,13 @@ def main():
         parser.print_help()
         sys.exit(0)
 
+    # When STARTTLS is requested without an explicit --connect-port, fall
+    # back to the protocol's default port (25/143/110) instead of 443.
+    starttls_default_ports = {"smtp": 25, "imap": 143, "pop3": 110}
+    user_supplied_port = '-P' in sys.argv or '--connect-port' in sys.argv
+    if args.starttls and not user_supplied_port and args.starttls in starttls_default_ports:
+        args.connect_port = starttls_default_ports[args.starttls]
+
     # Run the web server if the --server flag is set
     if args.server:
         if args.domains:
@@ -500,6 +520,7 @@ def main():
                         perform_ocsp_check=not args.no_ocsp_check,
                         perform_caa_check=not args.no_caa_check,
                         perform_hsts_check=not args.no_hsts_check,
+                        starttls=args.starttls,
                     )
                 )
                 print(" \033[92mdone\033[0m")
@@ -521,6 +542,7 @@ def main():
                 perform_ocsp_check=not args.no_ocsp_check,
                 perform_caa_check=not args.no_caa_check,
                 perform_hsts_check=not args.no_hsts_check,
+                starttls=args.starttls,
             )
 
 

--- a/src/check_tls/static/js/app.js
+++ b/src/check_tls/static/js/app.js
@@ -59,6 +59,14 @@ document.addEventListener('DOMContentLoaded', function() {
     return '<span class="badge badge-warning">?</span>';
   }
 
+  function alpnBadge(alpn) {
+    // Visualize the ALPN-negotiated application protocol returned by the server.
+    // h2 -> green; http/1.1 (or any other negotiated string) -> neutral; null -> grey N/A.
+    if (alpn === 'h2') return '<span class="badge badge-ok">h2</span>';
+    if (alpn) return '<span class="badge bg-secondary">' + escapeHtml(alpn) + '</span>';
+    return '<span class="badge bg-secondary">N/A</span>';
+  }
+
   function displayTlsVersion(version) {
     if (!version) return '-';
     return version === 'TLSv1.3' ? '' : version;
@@ -137,6 +145,7 @@ document.addEventListener('DOMContentLoaded', function() {
           <td data-bs-toggle="tooltip" data-bs-title="TLS version used for the connection and TLS 1.3 support.">${escapeHtml(displayTlsVersion(r.connection_health && r.connection_health.tls_version))}
               ${tls13Badge(r.connection_health && r.connection_health.supports_tls13)}
           </td>
+          <td data-bs-toggle="tooltip" data-bs-title="ALPN application protocol negotiated by the server (e.g. h2, http/1.1).">${alpnBadge(r.connection_health && r.connection_health.alpn_protocol)}</td>
           <td data-bs-toggle="tooltip" data-bs-title="Certificate Revocation List (CRL) check status for the leaf certificate.">${crlBadge(r.crl_check)}</td>
           <td data-bs-toggle="tooltip" data-bs-title="Online Certificate Status Protocol (OCSP) check status for the leaf certificate.">${ocspBadge(r.ocsp_check)}</td>
           <td data-bs-toggle="tooltip" data-bs-title="Presence of DNS CAA records for the domain.">${caaBadge(r.caa_check)}</td>
@@ -205,6 +214,7 @@ document.addEventListener('DOMContentLoaded', function() {
             <span class="fw-semibold text-muted">TLS:</span><br>
             <span class="fs-6">${escapeHtml(displayTlsVersion(result.connection_health && result.connection_health.tls_version))}</span>
             ${tls13Badge(result.connection_health && result.connection_health.supports_tls13)}
+            ${alpnBadge(result.connection_health && result.connection_health.alpn_protocol)}
           </div>
         </div>
         <!-- Alerts -->
@@ -494,6 +504,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const noOcspCheck = formData.get('no_ocsp_check') === 'true';
     const noCaaCheck = formData.get('no_caa_check') === 'true';
     const noHstsCheck = formData.get('no_hsts_check') === 'true';
+    const starttlsRaw = (formData.get('starttls') || '').trim();
+    const starttls = starttlsRaw === '' ? null : starttlsRaw;
 
     const payload = {
       domains: domainsArray,
@@ -503,7 +515,8 @@ document.addEventListener('DOMContentLoaded', function() {
       no_crl_check: noCrlCheck,
       no_ocsp_check: noOcspCheck,
       no_caa_check: noCaaCheck,
-      no_hsts_check: noHstsCheck
+      no_hsts_check: noHstsCheck,
+      starttls: starttls
     };
 
     fetch('/api/analyze', {

--- a/src/check_tls/templates/index.html
+++ b/src/check_tls/templates/index.html
@@ -30,7 +30,16 @@
         <label for="connect_port" class="form-label">Default Port</label>
         <input type="number" class="form-control" id="connect_port" name="connect_port" value="443" min="1" max="65535">
       </div>
-      <div class="col-12 col-md-10">
+      <div class="col-12 col-md-2">
+        <label for="starttls" class="form-label">STARTTLS</label>
+        <select class="form-select" id="starttls" name="starttls">
+          <option value="" selected>None (implicit TLS)</option>
+          <option value="smtp">SMTP (25/587)</option>
+          <option value="imap">IMAP (143)</option>
+          <option value="pop3">POP3 (110)</option>
+        </select>
+      </div>
+      <div class="col-12 col-md-8">
         <div class="d-flex flex-wrap gap-3 mt-4 justify-content-end" id="option-container">
           <div class="form-check">
             <input class="form-check-input" type="checkbox" id="insecure" name="insecure" value="true">
@@ -79,6 +88,7 @@
                 <th>Expires</th>
                 <th>Issuer</th>
                 <th>TLS</th>
+                <th>ALPN</th>
                 <th>CRL</th>
                 <th>OCSP</th>
                 <th>CAA</th>

--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -51,7 +51,9 @@ def _build_ssl_context(insecure: bool) -> ssl.SSLContext:
 
     The context disables automatic hostname checking so the leaf
     certificate can be retrieved even when the hostname does not match;
-    callers are expected to perform manual hostname validation.
+    callers are expected to perform manual hostname validation. ALPN is
+    advertised with ``h2`` and ``http/1.1`` so the negotiated protocol
+    can be reported back to the user.
 
     Parameters
     ----------
@@ -63,7 +65,8 @@ def _build_ssl_context(insecure: bool) -> ssl.SSLContext:
     Returns
     -------
     ssl.SSLContext
-        A configured SSL context with TLS 1.2 minimum (best effort).
+        A configured SSL context with TLS 1.2 minimum (best effort) and
+        ALPN protocols advertised.
     """
     logger = logging.getLogger("certcheck")
     context = ssl._create_unverified_context() if insecure else ssl.create_default_context()
@@ -73,6 +76,12 @@ def _build_ssl_context(insecure: bool) -> ssl.SSLContext:
         context.minimum_version = ssl.TLSVersion.TLSv1_2
     except AttributeError:
         logger.warning("Could not set minimum TLS version on context (might be older Python/SSL version).")
+
+    try:
+        context.set_alpn_protocols(["h2", "http/1.1"])
+    except (NotImplementedError, AttributeError):
+        # Older Python / SSL builds without ALPN support — silently skip.
+        logger.debug("ALPN not supported by this SSL build; skipping ALPN negotiation.")
 
     return context
 
@@ -97,11 +106,18 @@ def _extract_conn_info(ssock: ssl.SSLSocket) -> Dict[str, Any]:
         "tls_version": ssock.version(),
         "supports_tls13": False,
         "cipher_suite": None,
+        "alpn_protocol": None,
     }
     cipher_details = ssock.cipher()
     if cipher_details:
         info["cipher_suite"] = cipher_details[0]
     info["supports_tls13"] = info["tls_version"] == "TLSv1.3"
+
+    try:
+        info["alpn_protocol"] = ssock.selected_alpn_protocol()
+    except (AttributeError, NotImplementedError):
+        info["alpn_protocol"] = None
+
     return info
 
 
@@ -204,7 +220,8 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
     (x509.Certificate or None, dict or None)
         Tuple of the leaf certificate (when retrievable) and a connection
         info dictionary that always carries ``checked``, ``error``,
-        ``tls_version``, ``supports_tls13`` and ``cipher_suite`` keys.
+        ``tls_version``, ``supports_tls13``, ``cipher_suite`` and
+        ``alpn_protocol`` keys.
     """
     logger = logging.getLogger("certcheck")
     logger.debug(f"Connecting to {domain}:{port} to fetch certificate and connection info...")
@@ -217,6 +234,7 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
         "tls_version": None,
         "supports_tls13": None,
         "cipher_suite": None,
+        "alpn_protocol": None,
     }
 
     # Security validation: Check if the host resolves to private/internal IPs
@@ -254,7 +272,10 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
         # Capture TLS metadata
         conn_info.update(_extract_conn_info(ssock))
 
-        logger.info(f"Connection info for {domain}: TLS={conn_info['tls_version']}, Cipher={conn_info['cipher_suite']}")
+        logger.info(
+            f"Connection info for {domain}: TLS={conn_info['tls_version']}, "
+            f"Cipher={conn_info['cipher_suite']}, ALPN={conn_info['alpn_protocol']}"
+        )
 
         # Get the peer certificate in DER format
         der_cert = ssock.getpeercert(binary_form=True)
@@ -619,6 +640,7 @@ def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insec
             "tls_version": None,
             "supports_tls13": None,
             "cipher_suite": None,
+            "alpn_protocol": None,
         },
         "validation": {
             "system_trust_store": None,
@@ -996,7 +1018,7 @@ def run_analysis(domains_input: List[str], output_json: Optional[str] = None, ou
             # For now, keeping the original extensive header list
             writer.writerow([
                 'domain', 'status', 'error_message', 'analysis_timestamp',
-                'tls_checked', 'tls_error', 'tls_version', 'supports_tls13', 'cipher_suite',
+                'tls_checked', 'tls_error', 'tls_version', 'supports_tls13', 'cipher_suite', 'alpn_protocol',
                 'system_trust_store', 'validation_error',
                 'crl_checked', 'crl_leaf_status', 'crl_detail',
                 'ocsp_checked', 'ocsp_status', 'ocsp_detail',
@@ -1025,7 +1047,7 @@ def run_analysis(domains_input: List[str], output_json: Optional[str] = None, ou
                         res_item.get('domain'), res_item.get('status'), res_item.get('error_message'), res_item.get('analysis_timestamp'),
                         conn_health.get('checked'), conn_health.get('error'),
                         conn_health.get('tls_version'), conn_health.get('supports_tls13'),
-                        conn_health.get('cipher_suite'),
+                        conn_health.get('cipher_suite'), conn_health.get('alpn_protocol'),
                         validation_info.get('system_trust_store'), validation_info.get('error'),
                         crl_info.get('checked'), crl_info.get('leaf_status'),
                         json.dumps(crl_info.get('details')),
@@ -1043,7 +1065,7 @@ def run_analysis(domains_input: List[str], output_json: Optional[str] = None, ou
                             res_item.get('domain'), res_item.get('status'), res_item.get('error_message'), res_item.get('analysis_timestamp'),
                             conn_health.get('checked'), conn_health.get('error'),
                             conn_health.get('tls_version'), conn_health.get('supports_tls13'),
-                            conn_health.get('cipher_suite'),
+                            conn_health.get('cipher_suite'), conn_health.get('alpn_protocol'),
                             validation_info.get('system_trust_store'), validation_info.get('error'),
                             crl_info.get('checked'), crl_info.get('leaf_status'),
                             json.dumps(crl_info.get('details')),

--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -45,6 +45,158 @@ _EKU_LABELS = {
 }
 
 
+SUPPORTED_STARTTLS_PROTOCOLS = ("smtp", "imap", "pop3")
+
+
+def _recv_line(sock: socket.socket, max_bytes: int = 4096) -> bytes:
+    """
+    Read until LF or until the buffer cap is reached.
+
+    The helper is intentionally tiny: STARTTLS banners are short and we
+    only consume what's needed to advance the per-protocol state machine.
+
+    Parameters
+    ----------
+    sock : socket.socket
+        Plain TCP socket to read from.
+    max_bytes : int, optional
+        Safety cap to avoid runaway reads.
+
+    Returns
+    -------
+    bytes
+        The data read up to and including the first LF byte (if any).
+    """
+    chunks = []
+    total = 0
+    while total < max_bytes:
+        chunk = sock.recv(1)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += 1
+        if chunk == b"\n":
+            break
+    return b"".join(chunks)
+
+
+def _recv_smtp_response(sock: socket.socket) -> bytes:
+    """
+    Read a complete multi-line SMTP response.
+
+    SMTP servers may emit multi-line replies where every line except the
+    last starts with ``XYZ-`` and the final line uses ``XYZ ``. This helper
+    accumulates lines until the terminating space marker is seen.
+
+    Parameters
+    ----------
+    sock : socket.socket
+        Plain TCP socket connected to the SMTP server.
+
+    Returns
+    -------
+    bytes
+        The full multi-line response.
+    """
+    buf = b""
+    while True:
+        line = _recv_line(sock)
+        if not line:
+            break
+        buf += line
+        # Locate the start of the line we just appended.
+        if buf.endswith(b"\n"):
+            last_line_start = buf.rfind(b"\n", 0, len(buf) - 1) + 1
+        else:
+            last_line_start = 0
+        last_line = buf[last_line_start:]
+        # End of multi-line response: 4th char is space (vs '-' for continuation)
+        if len(last_line) >= 4 and last_line[3:4] == b" ":
+            break
+    return buf
+
+
+def _starttls_upgrade(sock: socket.socket, protocol: str) -> None:
+    """
+    Perform the STARTTLS negotiation for a known plaintext protocol.
+
+    Currently supports ``smtp``, ``imap`` and ``pop3``. ``ldap`` is *not*
+    supported because it requires ASN.1/BER-encoded extended request
+    framing; passing it raises :class:`ValueError` so callers can surface
+    a clear error to the user.
+
+    Parameters
+    ----------
+    sock : socket.socket
+        The plain TCP socket; on return it has spoken the STARTTLS dance
+        and is ready for ``context.wrap_socket``.
+    protocol : str
+        One of :data:`SUPPORTED_STARTTLS_PROTOCOLS`.
+
+    Raises
+    ------
+    ValueError
+        If the protocol is unknown or unsupported.
+    OSError
+        If the underlying socket fails or the server refuses to upgrade.
+    """
+    logger = logging.getLogger("certcheck")
+    proto = (protocol or "").lower()
+    sock.settimeout(10)
+
+    if proto == "smtp":
+        banner = _recv_smtp_response(sock)
+        if not banner.startswith(b"220"):
+            raise OSError(f"SMTP server did not greet with 220: {banner!r}")
+        sock.sendall(b"EHLO check-tls\r\n")
+        ehlo_resp = _recv_smtp_response(sock)
+        if not ehlo_resp.startswith(b"250"):
+            raise OSError(f"SMTP EHLO failed: {ehlo_resp!r}")
+        sock.sendall(b"STARTTLS\r\n")
+        starttls_resp = _recv_smtp_response(sock)
+        if not starttls_resp.startswith(b"220"):
+            raise OSError(f"SMTP STARTTLS rejected: {starttls_resp!r}")
+
+    elif proto == "imap":
+        banner = _recv_line(sock)
+        if not banner.startswith(b"* OK"):
+            raise OSError(f"IMAP server did not greet with * OK: {banner!r}")
+        sock.sendall(b"a001 STARTTLS\r\n")
+        # IMAP may emit untagged responses before the tagged completion.
+        for _ in range(8):
+            line = _recv_line(sock)
+            if not line:
+                raise OSError("IMAP STARTTLS: connection closed before tagged reply")
+            if line.startswith(b"a001 "):
+                if not line.startswith(b"a001 OK"):
+                    raise OSError(f"IMAP STARTTLS rejected: {line!r}")
+                break
+        else:
+            raise OSError("IMAP STARTTLS: no tagged reply received")
+
+    elif proto == "pop3":
+        banner = _recv_line(sock)
+        if not banner.startswith(b"+OK"):
+            raise OSError(f"POP3 server did not greet with +OK: {banner!r}")
+        sock.sendall(b"STLS\r\n")
+        resp = _recv_line(sock)
+        if not resp.startswith(b"+OK"):
+            raise OSError(f"POP3 STLS rejected: {resp!r}")
+
+    elif proto == "ldap":
+        raise ValueError(
+            "STARTTLS for LDAP is not supported by check-tls; use implicit "
+            "LDAPS (port 636) instead."
+        )
+    else:
+        raise ValueError(
+            f"Unsupported STARTTLS protocol '{protocol}'. "
+            f"Supported: {', '.join(SUPPORTED_STARTTLS_PROTOCOLS)}."
+        )
+
+    logger.debug(f"STARTTLS upgrade ({proto}) negotiated successfully.")
+
+
 def _build_ssl_context(insecure: bool) -> ssl.SSLContext:
     """
     Build an SSL context for outbound TLS handshakes.
@@ -165,7 +317,9 @@ def _verify_hostname_manually(cert: x509.Certificate, domain: str) -> Optional[s
     )
 
 
-def _fetch_unverified_cert(domain: str, port: int) -> Optional[x509.Certificate]:
+def _fetch_unverified_cert(
+    domain: str, port: int, starttls: Optional[str] = None
+) -> Optional[x509.Certificate]:
     """
     Open a fresh unverified TLS connection and return the peer certificate.
 
@@ -179,6 +333,9 @@ def _fetch_unverified_cert(domain: str, port: int) -> Optional[x509.Certificate]
         Server hostname.
     port : int
         Server TCP port.
+    starttls : str, optional
+        STARTTLS protocol to negotiate before the TLS handshake. Must be
+        one of :data:`SUPPORTED_STARTTLS_PROTOCOLS` when set.
 
     Returns
     -------
@@ -188,7 +345,14 @@ def _fetch_unverified_cert(domain: str, port: int) -> Optional[x509.Certificate]
     """
     alt_context = ssl._create_unverified_context()
     alt_context.check_hostname = False
+    try:
+        alt_context.set_alpn_protocols(["h2", "http/1.1"])
+    except (NotImplementedError, AttributeError):
+        pass
+
     with socket.create_connection((domain, port), timeout=10) as tmp_sock:
+        if starttls:
+            _starttls_upgrade(tmp_sock, starttls)
         with alt_context.wrap_socket(tmp_sock, server_hostname=domain) as tmp_ssock:
             der_cert = tmp_ssock.getpeercert(binary_form=True)
     if not der_cert:
@@ -196,14 +360,20 @@ def _fetch_unverified_cert(domain: str, port: int) -> Optional[x509.Certificate]
     return x509.load_der_x509_certificate(der_cert, default_backend())
 
 
-def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure: bool = False) -> Tuple[Optional[x509.Certificate], Optional[Dict[str, Any]]]:
+def fetch_leaf_certificate_and_conn_info(
+    domain: str,
+    port: int = 443,
+    insecure: bool = False,
+    starttls: Optional[str] = None,
+) -> Tuple[Optional[x509.Certificate], Optional[Dict[str, Any]]]:
     """
     Fetch the leaf TLS certificate and connection information from a server.
 
-    Public orchestrator: performs SSRF validation, opens a TCP connection,
-    runs the TLS handshake, captures connection metadata, retrieves the
-    leaf certificate, and runs manual hostname verification so mismatches
-    are reported in the returned ``error`` field instead of raising.
+    Public orchestrator: performs SSRF validation, opens a TCP connection
+    (optionally negotiating STARTTLS first), runs the TLS handshake,
+    captures connection metadata, retrieves the leaf certificate, and
+    runs manual hostname verification so mismatches are reported in the
+    returned ``error`` field instead of raising.
 
     Parameters
     ----------
@@ -214,6 +384,9 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
     insecure : bool, optional
         If True, ignore SSL certificate verification errors during the
         primary handshake.
+    starttls : str, optional
+        STARTTLS protocol to negotiate before TLS. One of
+        :data:`SUPPORTED_STARTTLS_PROTOCOLS`. ``None`` means implicit TLS.
 
     Returns
     -------
@@ -264,6 +437,13 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
         # validation and connect().
         connect_target = (resolved_ip or domain, port)
         sock = socket.create_connection(connect_target, timeout=10)
+
+        # Negotiate STARTTLS on the plain TCP socket before wrapping it
+        # with TLS, so SMTP/IMAP/POP3 servers that speak cleartext until
+        # the upgrade command can still be analysed.
+        if starttls:
+            _starttls_upgrade(sock, starttls)
+
         # Wrap socket with SSL context for TLS handshake; ``server_hostname``
         # stays the original domain so SNI and hostname matching work even
         # when the socket is connected to a pinned IP.
@@ -317,7 +497,7 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
 
         # Attempt to fetch the certificate using an unverified context to provide details
         try:
-            cert = _fetch_unverified_cert(domain, port)
+            cert = _fetch_unverified_cert(domain, port, starttls=starttls)
             if cert is not None:
                 san_hosts = extract_san(cert)
                 cn = get_common_name(cert.subject)
@@ -353,6 +533,13 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
 
     except socket.gaierror:
         error_msg = f"Could not resolve domain name: {domain}"
+        logger.error(error_msg)
+        conn_info["error"] = error_msg
+        return None, conn_info
+
+    except ValueError as e:
+        # Raised by _starttls_upgrade for unsupported protocols.
+        error_msg = f"STARTTLS error for {domain}: {e}"
         logger.error(error_msg)
         conn_info["error"] = error_msg
         return None, conn_info
@@ -465,22 +652,33 @@ def fetch_intermediate_certificates(cert: x509.Certificate) -> List[x509.Certifi
 
     return intermediates
 
-def validate_certificate_chain(domain: str, port: int = 443) -> Tuple[bool, Optional[str]]:
+def validate_certificate_chain(
+    domain: str, port: int = 443, starttls: Optional[str] = None
+) -> Tuple[bool, Optional[str]]:
     """
     Validate the certificate chain of a domain against the system's trust store.
 
-    Args:
-        domain (str): The domain to validate.
-        port (int): The port to connect to for validation.
+    Parameters
+    ----------
+    domain : str
+        The domain to validate.
+    port : int, optional
+        The port to connect to for validation.
+    starttls : str, optional
+        STARTTLS protocol to negotiate before TLS (``smtp``, ``imap``, ``pop3``).
 
-    Returns:
-        Tuple[bool, Optional[str]]: A tuple containing a boolean indicating success and
-        an optional error message with details when validation fails.
+    Returns
+    -------
+    (bool, str or None)
+        A tuple containing a boolean indicating success and an optional
+        error message with details when validation fails.
     """
     logger = logging.getLogger("certcheck")
     try:
         context = ssl.create_default_context()
         with socket.create_connection((domain, port), timeout=10) as sock:
+            if starttls:
+                _starttls_upgrade(sock, starttls)
             with context.wrap_socket(sock, server_hostname=domain) as ssock:
                 ssock.getpeercert()  # This implicitly validates the chain
         logger.info(f"SSL validation using system trust store OK for {domain}:{port}")
@@ -607,7 +805,7 @@ def detect_profile(cert: x509.Certificate) -> str:
 
     return profile
 
-def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insecure: bool = False, skip_transparency: bool = False, perform_crl_check: bool = True, perform_ocsp_check: bool = True, perform_caa_check: bool = True, perform_hsts_check: bool = True) -> dict:
+def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insecure: bool = False, skip_transparency: bool = False, perform_crl_check: bool = True, perform_ocsp_check: bool = True, perform_caa_check: bool = True, perform_hsts_check: bool = True, starttls: Optional[str] = None) -> dict:
     """
     Analyze the certificates of a domain, including leaf and intermediate certificates,
     perform validation, CRL, OCSP checks, and certificate transparency checks.
@@ -623,6 +821,8 @@ def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insec
         perform_caa_check (bool): Whether to check DNS CAA records.
         perform_hsts_check (bool): Whether to probe the HTTP Strict Transport
             Security policy via an HTTPS HEAD request.
+        starttls (str, optional): STARTTLS protocol to negotiate before TLS
+            (one of ``smtp``, ``imap``, ``pop3``). ``None`` means implicit TLS.
 
     Returns:
         dict: A dictionary containing analysis results, including connection info,
@@ -682,7 +882,9 @@ def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insec
     }
 
     logger.info(f"Fetching leaf certificate and connection info for {domain}:{port}...")
-    leaf_cert, conn_info = fetch_leaf_certificate_and_conn_info(domain, port=port, insecure=insecure)
+    leaf_cert, conn_info = fetch_leaf_certificate_and_conn_info(
+        domain, port=port, insecure=insecure, starttls=starttls
+    )
     if conn_info:
         result["connection_health"].update(conn_info)
         if conn_info.get("error") and not result["error_message"]:
@@ -697,7 +899,7 @@ def analyze_certificates(domain: str, port: int = 443, mode: str = "full", insec
 
     logger.info(f"Validating chain against system trust store for {domain}:{port}...")
     try:
-        is_valid, val_error = validate_certificate_chain(domain, port=port)
+        is_valid, val_error = validate_certificate_chain(domain, port=port, starttls=starttls)
         result["validation"]["system_trust_store"] = is_valid
         if val_error:
             result["validation"]["error"] = val_error
@@ -907,7 +1109,7 @@ def get_log_level(level_str: str):
     """
     return getattr(logging, level_str.upper(), logging.WARNING)
 
-def run_analysis(domains_input: List[str], output_json: Optional[str] = None, output_csv: Optional[str] = None, mode: str = "full", insecure: bool = False, skip_transparency: bool = False, perform_crl_check: bool = True, perform_ocsp_check: bool = True, perform_caa_check: bool = True, perform_hsts_check: bool = True):
+def run_analysis(domains_input: List[str], output_json: Optional[str] = None, output_csv: Optional[str] = None, mode: str = "full", insecure: bool = False, skip_transparency: bool = False, perform_crl_check: bool = True, perform_ocsp_check: bool = True, perform_caa_check: bool = True, perform_hsts_check: bool = True, starttls: Optional[str] = None):
     """
     Run TLS analysis for a list of domains (which can include ports) and output results.
 
@@ -922,6 +1124,8 @@ def run_analysis(domains_input: List[str], output_json: Optional[str] = None, ou
         perform_ocsp_check (bool): Perform OCSP checks.
         perform_caa_check (bool): Perform DNS CAA checks.
         perform_hsts_check (bool): Probe HTTP Strict Transport Security policy.
+        starttls (str, optional): STARTTLS protocol to negotiate before TLS
+            (``smtp``, ``imap``, ``pop3``). ``None`` means implicit TLS.
     """
     logger = logging.getLogger("certcheck")
     results = [] # Changed from all_results to results to match original variable name
@@ -950,6 +1154,7 @@ def run_analysis(domains_input: List[str], output_json: Optional[str] = None, ou
                 perform_ocsp_check=perform_ocsp_check,
                 perform_caa_check=perform_caa_check,
                 perform_hsts_check=perform_hsts_check,
+                starttls=starttls,
             )
         except Exception as e:
             analysis_ts = datetime.datetime.now(timezone.utc).isoformat()

--- a/src/check_tls/tls_checker.py
+++ b/src/check_tls/tls_checker.py
@@ -10,12 +10,14 @@ import csv
 from typing import List, Optional, Dict, Any, Tuple
 from concurrent.futures import ThreadPoolExecutor
 from check_tls.utils.cert_utils import (
+    assess_cert_quality,
     calculate_days_remaining,
     extract_san,
     get_common_name,
     get_public_key_details,
     get_sha256_fingerprint,
     get_signature_algorithm,
+    has_must_staple,
     has_scts,
 )
 from check_tls.utils.crl_utils import check_crl
@@ -43,43 +45,179 @@ _EKU_LABELS = {
 }
 
 
+def _build_ssl_context(insecure: bool) -> ssl.SSLContext:
+    """
+    Build an SSL context for outbound TLS handshakes.
+
+    The context disables automatic hostname checking so the leaf
+    certificate can be retrieved even when the hostname does not match;
+    callers are expected to perform manual hostname validation.
+
+    Parameters
+    ----------
+    insecure : bool
+        If True, return a fully unverified context (equivalent to
+        ``ssl._create_unverified_context``). Otherwise return the system
+        default context with ``check_hostname`` disabled.
+
+    Returns
+    -------
+    ssl.SSLContext
+        A configured SSL context with TLS 1.2 minimum (best effort).
+    """
+    logger = logging.getLogger("certcheck")
+    context = ssl._create_unverified_context() if insecure else ssl.create_default_context()
+    context.check_hostname = False
+
+    try:
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
+    except AttributeError:
+        logger.warning("Could not set minimum TLS version on context (might be older Python/SSL version).")
+
+    return context
+
+
+def _extract_conn_info(ssock: ssl.SSLSocket) -> Dict[str, Any]:
+    """
+    Extract TLS connection metadata from an established SSL socket.
+
+    Parameters
+    ----------
+    ssock : ssl.SSLSocket
+        The wrapped socket after a successful handshake.
+
+    Returns
+    -------
+    dict
+        A dictionary with ``tls_version``, ``supports_tls13`` and
+        ``cipher_suite`` populated. Always sets ``checked = True``.
+    """
+    info: Dict[str, Any] = {
+        "checked": True,
+        "tls_version": ssock.version(),
+        "supports_tls13": False,
+        "cipher_suite": None,
+    }
+    cipher_details = ssock.cipher()
+    if cipher_details:
+        info["cipher_suite"] = cipher_details[0]
+    info["supports_tls13"] = info["tls_version"] == "TLSv1.3"
+    return info
+
+
+def _verify_hostname_manually(cert: x509.Certificate, domain: str) -> Optional[str]:
+    """
+    Manually verify that ``domain`` matches one of the certificate's names.
+
+    Wildcard SANs are honored using ``ssl._dnsname_match``. When no name
+    matches, a detailed error string is returned including the certificate
+    validity window.
+
+    Parameters
+    ----------
+    cert : x509.Certificate
+        The leaf certificate retrieved from the server.
+    domain : str
+        The hostname the client expected to reach.
+
+    Returns
+    -------
+    str or None
+        ``None`` when the hostname matches; a human-readable error message
+        otherwise.
+    """
+    san_hosts = extract_san(cert)
+    cn = get_common_name(cert.subject)
+    names = san_hosts.copy()
+    if cn and cn not in names:
+        names.insert(0, cn)
+
+    # Use internal _dnsname_match for wildcard support similar to match_hostname.
+    # Signature is _dnsname_match(dn, hostname) — the certificate name (which
+    # may carry a wildcard) goes first, the hostname being checked second.
+    from ssl import _dnsname_match
+    if any(_dnsname_match(name, domain) for name in names):
+        return None
+
+    validity_info = (
+        f" Valid from {cert.not_valid_before_utc.isoformat()}"
+        f" to {cert.not_valid_after_utc.isoformat()}."
+    )
+    return (
+        f"Hostname mismatch: {domain} not in certificate names: "
+        f"{', '.join(names) if names else 'None'}." + validity_info
+    )
+
+
+def _fetch_unverified_cert(domain: str, port: int) -> Optional[x509.Certificate]:
+    """
+    Open a fresh unverified TLS connection and return the peer certificate.
+
+    Used as a fallback after an ``ssl.SSLCertVerificationError`` so the
+    caller can still surface certificate details (subject, SANs, validity)
+    even though the chain failed to validate.
+
+    Parameters
+    ----------
+    domain : str
+        Server hostname.
+    port : int
+        Server TCP port.
+
+    Returns
+    -------
+    x509.Certificate or None
+        The parsed peer certificate, or ``None`` if no certificate could
+        be retrieved.
+    """
+    alt_context = ssl._create_unverified_context()
+    alt_context.check_hostname = False
+    with socket.create_connection((domain, port), timeout=10) as tmp_sock:
+        with alt_context.wrap_socket(tmp_sock, server_hostname=domain) as tmp_ssock:
+            der_cert = tmp_ssock.getpeercert(binary_form=True)
+    if not der_cert:
+        return None
+    return x509.load_der_x509_certificate(der_cert, default_backend())
+
+
 def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure: bool = False) -> Tuple[Optional[x509.Certificate], Optional[Dict[str, Any]]]:
     """
-    Fetch the leaf TLS certificate and connection information from a domain's server.
+    Fetch the leaf TLS certificate and connection information from a server.
 
-    Parameters:
-        domain (str): The domain name to connect to.
-        port (int): The port number to connect to.
-        insecure (bool): If True, ignore SSL certificate verification errors.
+    Public orchestrator: performs SSRF validation, opens a TCP connection,
+    runs the TLS handshake, captures connection metadata, retrieves the
+    leaf certificate, and runs manual hostname verification so mismatches
+    are reported in the returned ``error`` field instead of raising.
 
-    Returns:
-        Tuple[Optional[x509.Certificate], Optional[Dict[str, Any]]]:
-            - The leaf x509 certificate if successfully fetched, else None.
-            - A dictionary with connection info including TLS version, cipher suite, and error details if any.
+    Parameters
+    ----------
+    domain : str
+        Server hostname.
+    port : int, optional
+        Server TCP port. Defaults to 443.
+    insecure : bool, optional
+        If True, ignore SSL certificate verification errors during the
+        primary handshake.
+
+    Returns
+    -------
+    (x509.Certificate or None, dict or None)
+        Tuple of the leaf certificate (when retrievable) and a connection
+        info dictionary that always carries ``checked``, ``error``,
+        ``tls_version``, ``supports_tls13`` and ``cipher_suite`` keys.
     """
     logger = logging.getLogger("certcheck")
     logger.debug(f"Connecting to {domain}:{port} to fetch certificate and connection info...")
 
-    # Create SSL context and disable automatic hostname checking so we can
-    # always retrieve the certificate even when mismatched. Manual validation
-    # will be performed after the TLS handshake.
-    context = ssl._create_unverified_context() if insecure else ssl.create_default_context()
-    context.check_hostname = False
+    context = _build_ssl_context(insecure=insecure)
 
-    # Initialize connection info dictionary with default values
-    conn_info = {
+    conn_info: Dict[str, Any] = {
         "checked": False,
         "error": None,
         "tls_version": None,
         "supports_tls13": None,
         "cipher_suite": None,
     }
-
-    try:
-        # Set minimum TLS version to 1.2 if supported by the SSL module
-        context.minimum_version = ssl.TLSVersion.TLSv1_2
-    except AttributeError:
-        logger.warning("Could not set minimum TLS version on context (might be older Python/SSL version).")
 
     # Security validation: Check if the host resolves to private/internal IPs
     # This prevents SSRF attacks by blocking connections to internal networks.
@@ -113,13 +251,8 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
         # when the socket is connected to a pinned IP.
         ssock = context.wrap_socket(sock, server_hostname=domain)
 
-        # Extract TLS version and cipher suite details
-        conn_info["tls_version"] = ssock.version()
-        cipher_details = ssock.cipher()
-        if cipher_details:
-            conn_info["cipher_suite"] = cipher_details[0]
-        conn_info["supports_tls13"] = conn_info["tls_version"] == "TLSv1.3"
-        conn_info["checked"] = True
+        # Capture TLS metadata
+        conn_info.update(_extract_conn_info(ssock))
 
         logger.info(f"Connection info for {domain}: TLS={conn_info['tls_version']}, Cipher={conn_info['cipher_suite']}")
 
@@ -135,24 +268,8 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
 
         # Manual hostname verification to capture detailed mismatch information
         ssock.getpeercert()
-        san_hosts = extract_san(cert)
-        cn = get_common_name(cert.subject)
-        names = san_hosts.copy()
-        if cn and cn not in names:
-            names.insert(0, cn)
-        # Use internal _dnsname_match for wildcard support similar to match_hostname.
-        # Signature is _dnsname_match(dn, hostname) — the certificate name (which
-        # may carry a wildcard) goes first, the hostname being checked second.
-        from ssl import _dnsname_match
-        if not any(_dnsname_match(name, domain) for name in names):
-            validity_info = (
-                f" Valid from {cert.not_valid_before_utc.isoformat()}"
-                f" to {cert.not_valid_after_utc.isoformat()}."
-            )
-            mismatch_detail = (
-                f"Hostname mismatch: {domain} not in certificate names: "
-                f"{', '.join(names) if names else 'None'}." + validity_info
-            )
+        mismatch_detail = _verify_hostname_manually(cert, domain)
+        if mismatch_detail:
             if insecure:
                 logger.warning(mismatch_detail + " (ignored due to insecure mode)")
             else:
@@ -179,13 +296,8 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
 
         # Attempt to fetch the certificate using an unverified context to provide details
         try:
-            alt_context = ssl._create_unverified_context()
-            alt_context.check_hostname = False
-            with socket.create_connection((domain, port), timeout=10) as tmp_sock:
-                with alt_context.wrap_socket(tmp_sock, server_hostname=domain) as tmp_ssock:
-                    der_cert = tmp_ssock.getpeercert(binary_form=True)
-            if der_cert:
-                cert = x509.load_der_x509_certificate(der_cert, default_backend())
+            cert = _fetch_unverified_cert(domain, port)
+            if cert is not None:
                 san_hosts = extract_san(cert)
                 cn = get_common_name(cert.subject)
                 names = san_hosts.copy()
@@ -197,9 +309,8 @@ def fetch_leaf_certificate_and_conn_info(domain: str, port: int = 443, insecure:
                 )
                 conn_info["error"] = error_msg + names_info + validity_info
                 return cert, conn_info
-            else:
-                conn_info["error"] = error_msg + " | No cert received in insecure fetch."
-                return None, conn_info
+            conn_info["error"] = error_msg + " | No cert received in insecure fetch."
+            return None, conn_info
         except Exception as inner_e:
             logger.error(
                 f"Failed to fetch certificate insecurely from {domain} after verification error: {inner_e}"

--- a/src/check_tls/web_server.py
+++ b/src/check_tls/web_server.py
@@ -166,12 +166,24 @@ def get_flask_app():
         no_caa_check_flag = bool(data.get('no_caa_check', False))
         no_hsts_check_flag = bool(data.get('no_hsts_check', False))
 
+        starttls_raw = data.get('starttls')
+        if isinstance(starttls_raw, str) and starttls_raw.strip().lower() in {"smtp", "imap", "pop3", "ldap"}:
+            starttls_flag = starttls_raw.strip().lower()
+        else:
+            starttls_flag = None
+
         try:
             connect_port_from_json = int(data.get('connect_port', 443))
             if not (1 <= connect_port_from_json <= 65535):
                 connect_port_from_json = 443
         except ValueError:
             connect_port_from_json = 443
+
+        # Adjust default port to the protocol's plaintext port when STARTTLS
+        # is requested and the client did not send an explicit port.
+        starttls_default_ports = {"smtp": 25, "imap": 143, "pop3": 110}
+        if starttls_flag in starttls_default_ports and 'connect_port' not in data:
+            connect_port_from_json = starttls_default_ports[starttls_flag]
 
         results = []
         for domain_entry in domains_input:
@@ -185,6 +197,7 @@ def get_flask_app():
                 perform_ocsp_check=not no_ocsp_check_flag,
                 perform_caa_check=not no_caa_check_flag,
                 perform_hsts_check=not no_hsts_check_flag,
+                starttls=starttls_flag,
             )
             # Include OCSP results in JSON API
             analysis_result["ocsp_check"] = analysis_result.get("ocsp_check", {})

--- a/tests/test_starttls.py
+++ b/tests/test_starttls.py
@@ -1,0 +1,289 @@
+"""
+End-to-end STARTTLS and ALPN tests.
+
+Spins up tiny in-process servers that speak the plaintext SMTP/IMAP/POP3
+banner+upgrade dance, then hand the socket to ``ssl.SSLContext.wrap_socket``
+in server mode. Verifies that ``analyze_certificates(... starttls="smtp")``
+(and friends) successfully retrieve the leaf certificate. ALPN tests use
+the same server scaffolding and assert the negotiated value surfaces in
+``connection_health.alpn_protocol``.
+"""
+
+from __future__ import annotations
+
+import socket
+import ssl
+import threading
+
+import pytest
+
+from check_tls.tls_checker import (
+    analyze_certificates,
+    fetch_leaf_certificate_and_conn_info,
+)
+from test_tls_checker import generate_self_signed_cert
+
+
+def _start_starttls_server(cert_path, key_path, protocol, alpn_select=None):
+    """
+    Run a single-shot plaintext-then-TLS server for SMTP/IMAP/POP3.
+
+    Parameters
+    ----------
+    cert_path : str
+        Path to a PEM certificate the TLS server will present.
+    key_path : str
+        Path to the matching PEM private key.
+    protocol : str
+        ``"smtp"``, ``"imap"`` or ``"pop3"``. Drives the banner exchange.
+    alpn_select : str or None
+        If set, the server advertises ALPN and forces the given protocol
+        as the negotiated value (mirrors what real servers do).
+
+    Returns
+    -------
+    (int, callable)
+        The bound port and a ``stop()`` callable that joins the thread.
+    """
+    listen_sock = socket.socket()
+    listen_sock.bind(("127.0.0.1", 0))
+    listen_sock.listen(1)
+    port = listen_sock.getsockname()[1]
+    stop_event = threading.Event()
+
+    def run():
+        try:
+            listen_sock.settimeout(5)
+            client, _ = listen_sock.accept()
+        except OSError:
+            return
+        try:
+            client.settimeout(5)
+
+            if protocol == "smtp":
+                client.sendall(b"220 test.example ESMTP ready\r\n")
+                # Read EHLO line.
+                _read_line(client)
+                client.sendall(b"250-test.example\r\n250 STARTTLS\r\n")
+                # Read STARTTLS line.
+                _read_line(client)
+                client.sendall(b"220 Ready to start TLS\r\n")
+            elif protocol == "imap":
+                client.sendall(b"* OK IMAP test ready\r\n")
+                _read_line(client)  # a001 STARTTLS
+                client.sendall(b"a001 OK Begin TLS negotiation now\r\n")
+            elif protocol == "pop3":
+                client.sendall(b"+OK POP3 test ready\r\n")
+                _read_line(client)  # STLS
+                client.sendall(b"+OK Begin TLS\r\n")
+            else:
+                raise RuntimeError(f"Unknown protocol {protocol}")
+
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.load_cert_chain(certfile=cert_path, keyfile=key_path)
+            if alpn_select:
+                ctx.set_alpn_protocols([alpn_select])
+
+            try:
+                with ctx.wrap_socket(client, server_side=True) as ssock:
+                    # Drain a byte to keep the client side blocking long
+                    # enough to retrieve the cert; we don't care otherwise.
+                    try:
+                        ssock.recv(1)
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+        finally:
+            try:
+                client.close()
+            except Exception:
+                pass
+            try:
+                listen_sock.close()
+            except Exception:
+                pass
+
+    def _read_line(s):
+        buf = b""
+        while not buf.endswith(b"\n") and len(buf) < 4096:
+            chunk = s.recv(1)
+            if not chunk:
+                break
+            buf += chunk
+        return buf
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+
+    def stop():
+        stop_event.set()
+        try:
+            listen_sock.close()
+        except Exception:
+            pass
+        thread.join(timeout=5)
+
+    return port, stop
+
+
+def _start_alpn_tls_server(cert_path, key_path, alpn_select=None):
+    """
+    Plain TLS server that optionally advertises ALPN.
+
+    Returns ``(port, stop)`` like the helper above. When ``alpn_select`` is
+    None, no ALPN is configured server-side, simulating servers that do
+    not negotiate ALPN at all.
+    """
+    listen_sock = socket.socket()
+    listen_sock.bind(("127.0.0.1", 0))
+    listen_sock.listen(1)
+    port = listen_sock.getsockname()[1]
+
+    def run():
+        try:
+            listen_sock.settimeout(5)
+            client, _ = listen_sock.accept()
+        except OSError:
+            return
+        try:
+            client.settimeout(5)
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.load_cert_chain(certfile=cert_path, keyfile=key_path)
+            if alpn_select:
+                ctx.set_alpn_protocols([alpn_select])
+            try:
+                with ctx.wrap_socket(client, server_side=True) as ssock:
+                    try:
+                        ssock.recv(1)
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+        finally:
+            try:
+                client.close()
+            except Exception:
+                pass
+            try:
+                listen_sock.close()
+            except Exception:
+                pass
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+
+    def stop():
+        try:
+            listen_sock.close()
+        except Exception:
+            pass
+        thread.join(timeout=5)
+
+    return port, stop
+
+
+def _redirect_to_localhost(monkeypatch):
+    """
+    Redirect outbound connections to 127.0.0.1 while preserving the port.
+
+    Lets us point the analyzer at a domain like ``starttls.test`` (which
+    fails the SAN/CN match unless the cert's SAN includes it) and still
+    have the TCP connection land on the test server bound to localhost.
+    """
+    real_create_connection = socket.create_connection
+
+    def redirected(address, *args, **kwargs):
+        host, p = address
+        return real_create_connection(("127.0.0.1", p), *args, **kwargs)
+
+    monkeypatch.setattr(socket, "create_connection", redirected)
+
+
+def test_alpn_negotiated_protocol_reported(monkeypatch):
+    """ALPN h2 negotiated server-side surfaces in conn_info.alpn_protocol."""
+    cert, cert_path, key_path = generate_self_signed_cert(
+        "alpn.test", ["alpn.test"],
+    )
+    port, stop = _start_alpn_tls_server(cert_path, key_path, alpn_select="h2")
+    _redirect_to_localhost(monkeypatch)
+    try:
+        leaf, conn_info = fetch_leaf_certificate_and_conn_info(
+            "alpn.test", port=port, insecure=True
+        )
+        assert leaf is not None
+        assert conn_info["alpn_protocol"] == "h2"
+    finally:
+        stop()
+
+
+def test_alpn_absent_when_server_does_not_negotiate(monkeypatch):
+    """When the server doesn't advertise ALPN, alpn_protocol stays None."""
+    cert, cert_path, key_path = generate_self_signed_cert(
+        "noalpn.test", ["noalpn.test"],
+    )
+    port, stop = _start_alpn_tls_server(cert_path, key_path, alpn_select=None)
+    _redirect_to_localhost(monkeypatch)
+    try:
+        leaf, conn_info = fetch_leaf_certificate_and_conn_info(
+            "noalpn.test", port=port, insecure=True
+        )
+        assert leaf is not None
+        assert conn_info["alpn_protocol"] is None
+    finally:
+        stop()
+
+
+@pytest.mark.parametrize("protocol", ["smtp", "imap", "pop3"])
+def test_starttls_handshake_retrieves_certificate(monkeypatch, protocol):
+    """STARTTLS upgrade succeeds for SMTP/IMAP/POP3 and returns the cert."""
+    cert, cert_path, key_path = generate_self_signed_cert(
+        "starttls.test", ["starttls.test"],
+    )
+    port, stop = _start_starttls_server(cert_path, key_path, protocol)
+    _redirect_to_localhost(monkeypatch)
+    try:
+        result = analyze_certificates(
+            "starttls.test",
+            port=port,
+            mode="simple",
+            insecure=True,
+            skip_transparency=True,
+            perform_crl_check=False,
+            perform_ocsp_check=False,
+            perform_caa_check=False,
+            starttls=protocol,
+        )
+        assert result["status"] != "failed", result.get("error_message")
+        assert result["connection_health"]["checked"] is True
+        assert result["certificates"], "no certificate parsed"
+        leaf = result["certificates"][0]
+        assert leaf["common_name"] == "starttls.test"
+    finally:
+        stop()
+
+
+def test_starttls_ldap_returns_clean_error():
+    """Requesting starttls='ldap' surfaces an explicit ValueError."""
+    from check_tls.tls_checker import _starttls_upgrade
+
+    s = socket.socket()
+    try:
+        with pytest.raises(ValueError) as exc_info:
+            _starttls_upgrade(s, "ldap")
+        assert "LDAP" in str(exc_info.value).upper()
+    finally:
+        s.close()
+
+
+def test_starttls_unknown_protocol_returns_clean_error():
+    """Unknown STARTTLS protocols raise ValueError, not a generic OSError."""
+    from check_tls.tls_checker import _starttls_upgrade
+
+    s = socket.socket()
+    try:
+        with pytest.raises(ValueError) as exc_info:
+            _starttls_upgrade(s, "ftp")
+        assert "ftp" in str(exc_info.value)
+    finally:
+        s.close()


### PR DESCRIPTION
## Summary

Three related improvements around the TLS connection path, delivered as
five atomic commits. Public API of `fetch_leaf_certificate_and_conn_info`
is unchanged for existing callers (new `starttls` kwarg defaults to `None`).

### Goal 1 — refactor `fetch_leaf_certificate_and_conn_info`

The 180-line orchestrator is decomposed into focused helpers:

- `_build_ssl_context(insecure)` — context creation with TLS 1.2 minimum
  and ALPN advertisement
- `_extract_conn_info(ssock)` — TLS version, cipher, ALPN, supports_tls13
- `_verify_hostname_manually(cert, domain)` — returns mismatch error or None
- `_fetch_unverified_cert(domain, port, starttls)` — replaces the inline
  `alt_context` block reused after `SSLCertVerificationError`

Public signature and return shape unchanged. The 41 existing tests stay
green throughout each commit.

### Goal 2 — ALPN protocol reporting

The SSL context now advertises `["h2", "http/1.1"]` and the negotiated
value is exposed as `connection_health.alpn_protocol` (None when the
server doesn't negotiate ALPN).

- CLI: `print_human_summary` prints `ALPN: h2` (green) / negotiated value
  / `N/A` in the Connection Health block
- Web UI: summary table gets a new ALPN column; result card synthesis row
  shows an `alpnBadge` next to TLS
- CSV: new `alpn_protocol` column

### Goal 3 — STARTTLS for SMTP/IMAP/POP3

A new `--starttls {smtp,imap,pop3,ldap}` flag (CLI) and `starttls` JSON
field (API) drive a per-protocol upgrade dance via `_starttls_upgrade()`:

- SMTP: 220 banner -> EHLO -> STARTTLS -> 220
- IMAP: `* OK` banner -> `a001 STARTTLS` -> tagged OK
- POP3: `+OK` banner -> `STLS` -> `+OK`

When `--connect-port` is not supplied, the default flips to the
protocol's plaintext port (smtp=25, imap=143, pop3=110).

**Trade-off / LDAP**: LDAP StartTLS requires ASN.1/BER-encoded extended
request framing, which would mean adding new dependencies or a
hand-rolled BER encoder. Scope kept tight: `--starttls ldap` raises a
clear `ValueError` ("use implicit LDAPS on 636 instead") that surfaces
in `connection_health.error` and the CLI/API responses. Documented as
unsupported.

## Test plan

- [x] `ALLOW_INTERNAL_IPS=true uv run pytest tests/ -v` — 48 passed
  (41 baseline + 7 new)
- [x] `uv run --with ruff ruff check src/ tests/` — no new errors
  introduced (pre-existing wildcard-import / unused-`e` errors untouched)
- [x] New tests in `tests/test_starttls.py`:
  - ALPN h2 negotiated server-side surfaces correctly
  - ALPN absent when server doesn't advertise
  - STARTTLS handshakes for SMTP/IMAP/POP3 (parametrized) retrieve the cert
  - LDAP STARTTLS raises a clean `ValueError`
  - Unknown protocols raise `ValueError`, not `OSError`
- [x] Manual smoke test of CLI: `python -m check_tls.main --help` shows
  `--starttls`